### PR TITLE
Pipper/talent

### DIFF
--- a/@/components/ui/context-window-ring.tsx
+++ b/@/components/ui/context-window-ring.tsx
@@ -201,7 +201,7 @@ function ContextUsagePanel({
                   </dd>
                 </div>
               )}
-              {autoCompactionEnabled && (
+              {/*{autoCompactionEnabled && (
                 <div className="flex items-baseline justify-between gap-3">
                   <dt className="text-muted-foreground">Auto-compaction</dt>
                   <dd
@@ -211,23 +211,15 @@ function ContextUsagePanel({
                     On
                   </dd>
                 </div>
-              )}
+              )}*/}
             </dl>
           </>
         )}
 
         {showSession && (
           <>
-            <div className="border-t border-border/60" />
+
             <dl className="space-y-1.5">
-              {typeof sessionTokens === "number" && sessionTokens > 0 && (
-                <div className="flex items-baseline justify-between gap-3">
-                  <dt className="text-muted-foreground">Session tokens</dt>
-                  <dd className="tabular-nums text-foreground">
-                    {formatTokenCount(sessionTokens)}
-                  </dd>
-                </div>
-              )}
               {typeof sessionCost === "number" && sessionCost > 0 && (
                 <div className="flex items-baseline justify-between gap-3">
                   <dt className="text-muted-foreground">Session cost</dt>
@@ -255,18 +247,7 @@ function ContextUsagePanel({
                 >
                   {rateLimitPercentLeftValue}% left
                 </p>
-              ) : (
-                <p
-                  className={cn("mt-1", rateLimitTextColor)}
-                  style={{ fontVariationSettings: fontWeights.medium }}
-                >
-                  {rateLimit.status === "rejected"
-                    ? "Limit reached"
-                    : rateLimit.status === "allowed_warning"
-                      ? "Approaching limit"
-                      : "Within limit"}
-                </p>
-              )}
+              ) : null}
               {rateLimitReset && (
                 <p className="mt-1 text-muted-foreground/80">
                   {rateLimitReset.charAt(0).toUpperCase() + rateLimitReset.slice(1)}

--- a/@/components/ui/context-window-ring.tsx
+++ b/@/components/ui/context-window-ring.tsx
@@ -9,11 +9,67 @@ import { Elevated } from "@/lib/elevated";
 import { fontWeights } from "@/lib/font-weight";
 import { shapeMap } from "@/lib/shape-context";
 import { springs } from "@/lib/springs";
+import type { AcpRateLimitInfo } from "../../../contracts/acp.ts";
 
 export interface ContextUsageSnapshot {
   tokens: number | null;
   contextWindow: number;
   percent: number | null;
+}
+
+/** Human label for a rate-limit window; falls back to prettifying the raw id. */
+function rateLimitLabel(type?: string): string {
+  switch (type) {
+    case "five_hour":
+      return "5-hour limit";
+    case "seven_day":
+    case "seven_day_overage_included":
+      return "Weekly limit";
+    case "seven_day_opus":
+      return "Weekly limit (Opus)";
+    case "seven_day_sonnet":
+      return "Weekly limit (Sonnet)";
+    case "overage":
+      return "Overage";
+    default:
+      return type
+        ? type.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase())
+        : "Rate limit";
+  }
+}
+
+/** Percent of the window remaining (0–100), or null when utilization is absent. */
+function rateLimitPercentLeft(utilization?: number): number | null {
+  if (typeof utilization !== "number" || Number.isNaN(utilization)) return null;
+  // Utilization may arrive as a 0–1 fraction or an already-scaled 0–100 percent.
+  const usedPct = utilization <= 1 ? utilization * 100 : utilization;
+  return Math.min(100, Math.max(0, Math.round(100 - usedPct)));
+}
+
+/** Relative "resets in …" text; null when no reset timestamp is provided. */
+function formatRateLimitReset(resetsAt?: number): string | null {
+  if (typeof resetsAt !== "number" || resetsAt <= 0) return null;
+  // Accept seconds or milliseconds since epoch.
+  const epochMs = resetsAt > 1e12 ? resetsAt : resetsAt * 1000;
+  const deltaMs = epochMs - Date.now();
+  if (deltaMs <= 0) return "resets soon";
+  const totalMin = Math.round(deltaMs / 60_000);
+  const hours = Math.floor(totalMin / 60);
+  const mins = totalMin % 60;
+  if (hours >= 24) {
+    const days = Math.floor(hours / 24);
+    const restHours = hours % 24;
+    return `resets in ${days}d${restHours ? ` ${restHours}h` : ""}`;
+  }
+  if (hours > 0) return `resets in ${hours}h${mins ? ` ${mins}m` : ""}`;
+  return `resets in ${mins}m`;
+}
+
+function rateLimitColor(status: AcpRateLimitInfo["status"], percentLeft: number | null): string {
+  if (status === "rejected") return "text-destructive";
+  if (status === "allowed_warning") return "text-amber-500 dark:text-amber-400";
+  if (percentLeft !== null && percentLeft <= 10) return "text-amber-500 dark:text-amber-400";
+  return "text-foreground/80";
 }
 
 interface ContextWindowRingProps {
@@ -24,6 +80,8 @@ interface ContextWindowRingProps {
   autoCompactionEnabled?: boolean;
   sessionTokens?: number;
   sessionCost?: number;
+  /** Subscription rate limit, when the agent reports one. Section is hidden otherwise. */
+  rateLimit?: AcpRateLimitInfo | null;
   size?: number;
   className?: string;
 }
@@ -54,6 +112,7 @@ interface ContextUsagePanelProps {
   autoCompactionEnabled?: boolean;
   sessionTokens?: number;
   sessionCost?: number;
+  rateLimit?: AcpRateLimitInfo | null;
   fillColor: string;
 }
 
@@ -63,6 +122,7 @@ function ContextUsagePanel({
   autoCompactionEnabled,
   sessionTokens,
   sessionCost,
+  rateLimit,
   fillColor,
 }: ContextUsagePanelProps) {
   const { tokens, contextWindow, percent } = contextUsage;
@@ -71,6 +131,13 @@ function ContextUsagePanel({
     (typeof sessionTokens === "number" && sessionTokens > 0) ||
     (typeof sessionCost === "number" && sessionCost > 0);
   const showDetails = Boolean(modelName || autoCompactionEnabled);
+  const rateLimitPercentLeftValue = rateLimit
+    ? rateLimitPercentLeft(rateLimit.utilization)
+    : null;
+  const rateLimitReset = rateLimit ? formatRateLimitReset(rateLimit.resetsAt) : null;
+  const rateLimitTextColor = rateLimit
+    ? rateLimitColor(rateLimit.status, rateLimitPercentLeftValue)
+    : "";
 
   return (
     <Elevated
@@ -170,6 +237,44 @@ function ContextUsagePanel({
             </dl>
           </>
         )}
+
+        {rateLimit && (
+          <>
+            <div className="border-t border-border/60" />
+            <div>
+              <p
+                className="text-muted-foreground"
+                style={{ fontVariationSettings: fontWeights.medium }}
+              >
+                {rateLimitLabel(rateLimit.rateLimitType)}
+              </p>
+              {rateLimitPercentLeftValue !== null ? (
+                <p
+                  className={cn("mt-1 tabular-nums", rateLimitTextColor)}
+                  style={{ fontVariationSettings: fontWeights.medium }}
+                >
+                  {rateLimitPercentLeftValue}% left
+                </p>
+              ) : (
+                <p
+                  className={cn("mt-1", rateLimitTextColor)}
+                  style={{ fontVariationSettings: fontWeights.medium }}
+                >
+                  {rateLimit.status === "rejected"
+                    ? "Limit reached"
+                    : rateLimit.status === "allowed_warning"
+                      ? "Approaching limit"
+                      : "Within limit"}
+                </p>
+              )}
+              {rateLimitReset && (
+                <p className="mt-1 text-muted-foreground/80">
+                  {rateLimitReset.charAt(0).toUpperCase() + rateLimitReset.slice(1)}
+                </p>
+              )}
+            </div>
+          </>
+        )}
       </div>
     </Elevated>
   );
@@ -182,6 +287,7 @@ export function ContextWindowRing({
   autoCompactionEnabled,
   sessionTokens,
   sessionCost,
+  rateLimit,
   size = 20,
   className,
 }: ContextWindowRingProps) {
@@ -284,6 +390,7 @@ export function ContextWindowRing({
                   autoCompactionEnabled={autoCompactionEnabled}
                   sessionTokens={sessionTokens}
                   sessionCost={sessionCost}
+                  rateLimit={rateLimit}
                   fillColor={fillColor}
                 />
               </motion.div>

--- a/@/components/ui/context-window-ring.tsx
+++ b/@/components/ui/context-window-ring.tsx
@@ -41,9 +41,8 @@ function rateLimitLabel(type?: string): string {
 /** Percent of the window remaining (0–100), or null when utilization is absent. */
 function rateLimitPercentLeft(utilization?: number): number | null {
   if (typeof utilization !== "number" || Number.isNaN(utilization)) return null;
-  // Utilization may arrive as a 0–1 fraction or an already-scaled 0–100 percent.
-  const usedPct = utilization <= 1 ? utilization * 100 : utilization;
-  return Math.min(100, Math.max(0, Math.round(100 - usedPct)));
+  // `utilization` is already a canonical 0–100 percent (normalized at the reducer).
+  return Math.min(100, Math.max(0, Math.round(100 - utilization)));
 }
 
 /** Relative "resets in …" text; null when no reset timestamp is provided. */

--- a/contracts/acp.ts
+++ b/contracts/acp.ts
@@ -87,10 +87,31 @@ export interface AgentProbeResult {
   authMethods?: AuthMethod[];
 }
 
+/**
+ * Account-level subscription rate limit for a session, when the agent reports
+ * one. Distinct from `used`/`size` (per-turn context window): this describes the
+ * plan's rolling usage window (e.g. Claude's 5-hour / weekly limits). Today only
+ * the Claude ACP adapter surfaces this — it rides a `usage_update` whose
+ * `_meta["_claude/rateLimit"]` carries the SDK's `rate_limit_info`. Other agents
+ * leave it null, so the UI simply omits the section for them.
+ */
+export interface AcpRateLimitInfo {
+  /** Gate state for the account's subscription limits. */
+  status: "allowed" | "allowed_warning" | "rejected" | (string & {});
+  /** Which limit window this describes, e.g. `five_hour` | `seven_day`. */
+  rateLimitType?: string;
+  /** Fraction of the window consumed. May arrive as 0–1 or 0–100; normalized at render. */
+  utilization?: number;
+  /** Unix epoch seconds when the window resets. */
+  resetsAt?: number;
+}
+
 export interface AcpUsageState {
   used: number;
   size: number;
   cost?: { amount: number; currency: string };
+  /** Subscription rate limit, when the agent reports one; null otherwise. */
+  rateLimit?: AcpRateLimitInfo | null;
 }
 
 export interface AcpToolCallState {

--- a/contracts/acp.ts
+++ b/contracts/acp.ts
@@ -100,7 +100,11 @@ export interface AcpRateLimitInfo {
   status: "allowed" | "allowed_warning" | "rejected" | (string & {});
   /** Which limit window this describes, e.g. `five_hour` | `seven_day`. */
   rateLimitType?: string;
-  /** Fraction of the window consumed. May arrive as 0–1 or 0–100; normalized at render. */
+  /**
+   * Percent of the window consumed, 0–100. Normalized to this scale at the
+   * reducer boundary from whatever native scale the source reports (Claude
+   * emits a 0–1 fraction), so consumers can use it directly without guessing.
+   */
   utilization?: number;
   /** Unix epoch seconds when the window resets. */
   resetsAt?: number;

--- a/src/components/agent-continue-menu.tsx
+++ b/src/components/agent-continue-menu.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
+import { Button } from "@/components/ui/button";
+import type { AcpAgentDescriptor } from "../../contracts/acp.ts";
+
+interface AgentContinueMenuProps {
+  agents: AcpAgentDescriptor[];
+  selectedIndex: number;
+  onSelect: (agentId: string) => void;
+}
+
+/**
+ * Agent picker shown when the user runs `/continue` — mirrors the slash-command
+ * menu so switching agents to fork a conversation feels like the same surface.
+ */
+export function AgentContinueMenu({ agents, selectedIndex, onSelect }: AgentContinueMenuProps) {
+  const prefersReducedMotion = useReducedMotion();
+
+  return (
+    <AnimatePresence initial={false}>
+      {agents.length > 0 && (
+        <motion.div
+          key="continue-agents"
+          data-pipper-id="continue-agents"
+          initial={{
+            opacity: 0,
+            y: prefersReducedMotion ? 0 : 24,
+            scale: prefersReducedMotion ? 1 : 0.98,
+          }}
+          animate={{ opacity: 1, y: 0, scale: 1 }}
+          exit={
+            prefersReducedMotion
+              ? { opacity: 0, transition: { duration: 0 } }
+              : {
+                  opacity: 0,
+                  y: 12,
+                  scale: 0.99,
+                  transition: { duration: 0.15, ease: "easeIn" },
+                }
+          }
+          transition={
+            prefersReducedMotion ? { duration: 0 } : { type: "spring", duration: 0.3, bounce: 0 }
+          }
+          style={{ transformOrigin: "bottom center" }}
+          className="absolute inset-x-5 bottom-[calc(100%-12px)] z-0 overflow-hidden rounded-t-xl border border-border bg-surface-2 px-2 pb-5 pt-2 shadow-lg"
+        >
+          <div className="px-2 pb-1.5 pt-0.5 text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+            Continue with
+          </div>
+          <div className="flex max-h-64 flex-col gap-1 overflow-y-auto">
+            {agents.slice(0, 8).map((agent, index) => (
+              <Button
+                key={agent.id}
+                variant="ghost"
+                size="sm"
+                active={selectedIndex === index}
+                className="w-full justify-start"
+                onClick={() => onSelect(agent.id)}
+              >
+                {agent.displayName}
+              </Button>
+            ))}
+          </div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/src/components/agent-continue-menu.tsx
+++ b/src/components/agent-continue-menu.tsx
@@ -2,6 +2,7 @@
 
 import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
 import { Button } from "@/components/ui/button";
+import { Elevated } from "@/lib/elevated";
 import type { AcpAgentDescriptor } from "../../contracts/acp.ts";
 
 interface AgentContinueMenuProps {
@@ -43,25 +44,30 @@ export function AgentContinueMenu({ agents, selectedIndex, onSelect }: AgentCont
             prefersReducedMotion ? { duration: 0 } : { type: "spring", duration: 0.3, bounce: 0 }
           }
           style={{ transformOrigin: "bottom center" }}
-          className="absolute inset-x-5 bottom-[calc(100%-12px)] z-0 overflow-hidden rounded-t-xl border border-border bg-surface-2 px-2 pb-5 pt-2 shadow-lg"
+          className="absolute inset-x-5 bottom-[calc(100%-12px)] z-0"
         >
-          <div className="px-2 pb-1.5 pt-0.5 text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
-            Continue with
-          </div>
-          <div className="flex max-h-64 flex-col gap-1 overflow-y-auto">
-            {agents.slice(0, 8).map((agent, index) => (
-              <Button
-                key={agent.id}
-                variant="ghost"
-                size="sm"
-                active={selectedIndex === index}
-                className="w-full justify-start"
-                onClick={() => onSelect(agent.id)}
-              >
-                {agent.displayName}
-              </Button>
-            ))}
-          </div>
+          <Elevated
+            offset={2}
+            className="overflow-hidden rounded-t-xl border border-border px-2 pb-5 pt-2 shadow-lg"
+          >
+            <div className="px-2 pb-1.5 pt-0.5 text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+              Continue with
+            </div>
+            <div className="flex max-h-64 flex-col gap-1 overflow-y-auto">
+              {agents.map((agent, index) => (
+                <Button
+                  key={agent.id}
+                  variant="ghost"
+                  size="sm"
+                  active={selectedIndex === index}
+                  className="w-full justify-start"
+                  onClick={() => onSelect(agent.id)}
+                >
+                  {agent.displayName}
+                </Button>
+              ))}
+            </div>
+          </Elevated>
         </motion.div>
       )}
     </AnimatePresence>

--- a/src/components/agent-panel.tsx
+++ b/src/components/agent-panel.tsx
@@ -5,9 +5,11 @@ import { AnimatePresence, motion } from "framer-motion";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import {
   CheckIcon as ModelCheckIcon,
+  ChatCircleTextIcon,
   MagnifyingGlassIcon,
   PaperclipIcon,
   WarningIcon,
+  XIcon,
 } from "@phosphor-icons/react";
 import { Button } from "@/components/ui/button";
 import { InputMessage } from "@/components/ui/input-message";
@@ -29,10 +31,20 @@ import { ThinkingIndicator } from "@/components/ui/thinking-indicator";
 import { ContextWindowRing } from "@/components/ui/context-window-ring";
 import { AmbientPixelField } from "@/components/ambient-pixel-field";
 import { AgentSlashCommandMenu } from "@/components/agent-slash-command-menu";
+import { AgentContinueMenu } from "@/components/agent-continue-menu";
 import { AgentQuestionCard, AgentQuestionDock } from "@/components/agent-question";
 import { cn } from "@/lib/utils";
 import { toast } from "@/components/ui/toast";
 import type { AgentPanelSnapshot } from "@/store/agent-store";
+import { useContinuationStore } from "@/store/continuation-store";
+import {
+  buildContinuationText,
+  extractConversation,
+  formatTranscript,
+  hasConversation,
+  type TranscriptSourceMessage,
+} from "@/lib/acp-transcript";
+import type { ContentBlock } from "../../contracts/acp.ts";
 import { stringifyMessageContent, type MessageLike } from "@/lib/message-utils";
 import {
   extractGroupedMessageImages,
@@ -41,7 +53,7 @@ import {
   partitionValidImageFiles,
   type ChatImageAttachment,
 } from "@/lib/agent-message-images";
-import { matchAgentCommands, mergeAgentCommands } from "@/lib/agent-commands";
+import { CONTINUE_COMMAND, matchAgentCommands, mergeAgentCommands } from "@/lib/agent-commands";
 import { isSubagentTrigger, SUBAGENT_COMMAND } from "@/lib/subagent-orchestration";
 import { SubagentComposer, type SubagentComposerSubmit } from "@/components/subagent-composer";
 import { SubagentActivity } from "@/components/subagent-activity";
@@ -536,6 +548,8 @@ export function AgentPanel() {
   const [isRuntimeActionPending, setIsRuntimeActionPending] = useState(false);
   const [streamingBehavior, setStreamingBehavior] = useState<"followUp" | "steer">("followUp");
   const [selectedCommandIndex, setSelectedCommandIndex] = useState(0);
+  const [continuePickerOpen, setContinuePickerOpen] = useState(false);
+  const [continueSelectedIndex, setContinueSelectedIndex] = useState(0);
   const [orchestrationOpen, setOrchestrationOpen] = useState(false);
   const [orchestrationSeed, setOrchestrationSeed] = useState("");
   const [editState, setEditState] = useState<{
@@ -569,6 +583,15 @@ export function AgentPanel() {
     [snapshot?.commands],
   );
   const registryAgents = useAgentRegistryStore((state) => state.agents);
+  // Agents offered by `/continue` — only ones the user can actually connect to.
+  const continuableAgents = useMemo(
+    () => registryAgents.filter((agent) => agent.available !== false),
+    [registryAgents],
+  );
+  // Carry-over transcript staged for the currently-viewed thread, if any.
+  const pendingContinuation = useContinuationStore((state) =>
+    snapshot?.threadId ? (state.pendingByThreadId[snapshot.threadId] ?? null) : null,
+  );
   const modelName = snapshot?.model?.name ?? "No model";
   const models = snapshot?.models ?? [];
 
@@ -918,6 +941,13 @@ export function AgentPanel() {
         });
         return;
       }
+      // A `/continue` thread carries an unsent transcript: send it as its own
+      // content block alongside the user's message so the agent gets the prior
+      // context, while `message` (the optimistic bubble) stays just the user's
+      // own text — the transcript never renders as a giant user bubble.
+      const pendingTranscript = operationThreadId
+        ? useContinuationStore.getState().getPending(operationThreadId)
+        : null;
       // The underlying ACP call only resolves once the agent finishes its
       // entire turn, so we deliberately don't await it here — awaiting would
       // hold composerDisabled (and this stale draft text) for the whole turn.
@@ -932,12 +962,27 @@ export function AgentPanel() {
               message: trimmed,
               images,
             })
-          : sendPrompt({
-              threadId: operationThreadId,
-              message: trimmed,
-              images: newImages.length ? newImages : undefined,
-              streamingBehavior: isStreaming ? streamingBehavior : undefined,
-            });
+          : pendingTranscript
+            ? sendPrompt({
+                threadId: operationThreadId,
+                message: trimmed,
+                prompt: [
+                  { type: "text", text: buildContinuationText(pendingTranscript) },
+                  ...(trimmed ? [{ type: "text", text: trimmed }] : []),
+                  ...newImages.map((img) => ({
+                    type: "image",
+                    data: img.data,
+                    mimeType: img.mimeType,
+                  })),
+                ] as ContentBlock[],
+                streamingBehavior: isStreaming ? streamingBehavior : undefined,
+              })
+            : sendPrompt({
+                threadId: operationThreadId,
+                message: trimmed,
+                images: newImages.length ? newImages : undefined,
+                streamingBehavior: isStreaming ? streamingBehavior : undefined,
+              });
       sendOp.catch((err) => {
         toast({
           icon: <WarningIcon className="size-5 text-red-500" />,
@@ -949,6 +994,12 @@ export function AgentPanel() {
         setInputValue("");
         setAttachedFiles([]);
         setEditState(null);
+        // Chip is consumed on send. Optimistic clear: the message is already
+        // in flight, and a failed first send is recoverable by re-running
+        // `/continue` from the source thread.
+        if (pendingTranscript && operationThreadId) {
+          useContinuationStore.getState().clearPending(operationThreadId);
+        }
       }
       setStreamingBehavior("followUp");
     } catch (err) {
@@ -1006,7 +1057,78 @@ export function AgentPanel() {
       openOrchestration("");
       return;
     }
+    if (commandName === CONTINUE_COMMAND) {
+      if (!hasConversation(activeMessages as TranscriptSourceMessage[])) {
+        toast({
+          icon: <WarningIcon className="size-5 text-red-500" />,
+          title: "Nothing to continue",
+          description: "This conversation has no messages to carry over yet.",
+        });
+        setInputValue("");
+        return;
+      }
+      setInputValue("");
+      setSelectedCommandIndex(0);
+      setContinueSelectedIndex(0);
+      setContinuePickerOpen(true);
+      return;
+    }
     setInputValue(`/${commandName} `);
+  };
+
+  // `/continue` picks a target agent, snapshots this thread's user/assistant
+  // transcript, and opens a fresh thread on that agent seeded with the
+  // transcript (staged as a composer chip until the user sends).
+  const handleContinueWithAgent = async (agentId: string) => {
+    setContinuePickerOpen(false);
+    const turns = extractConversation(activeMessages as TranscriptSourceMessage[]);
+    if (turns.length === 0) {
+      toast({
+        icon: <WarningIcon className="size-5 text-red-500" />,
+        title: "Nothing to continue",
+        description: "This conversation has no messages to carry over yet.",
+      });
+      return;
+    }
+    const projectId = activeProject?.id ?? snapshot?.projectId ?? null;
+    if (!projectId) {
+      toast({
+        icon: <WarningIcon className="size-5 text-red-500" />,
+        title: "No project",
+        description: "Open a project before continuing a conversation.",
+      });
+      return;
+    }
+    setIsSubmitting(true);
+    try {
+      // The new thread binds to the workspace the user is looking at, like any
+      // other new thread.
+      const worktreePath = normalizeWorkspacePath(
+        useWorktreeStore.getState().selectedWorktreePathByProject[projectId],
+        activeProject?.path ?? null,
+      );
+      const thread = await createThread(
+        projectId,
+        `Continued: ${snapshot?.title ?? "conversation"}`,
+        snapshot?.threadId ?? null,
+        agentId,
+        worktreePath,
+      );
+      // Stage the transcript before selecting the thread so the chip is present
+      // the moment its composer renders.
+      useContinuationStore.getState().setPending(thread.id, formatTranscript(turns));
+      await loadProjectThreads(projectId, { reset: true });
+      await selectThread(thread.id);
+    } catch (err) {
+      toast({
+        icon: <WarningIcon className="size-5 text-red-500" />,
+        title: "Continue failed",
+        description:
+          err instanceof Error ? err.message : "Could not start the new conversation.",
+      });
+    } finally {
+      setIsSubmitting(false);
+    }
   };
 
   const handleOrchestrationSubmit = async ({
@@ -1430,6 +1552,14 @@ export function AgentPanel() {
                     onSelect={applyCommand}
                   />
 
+                  {continuePickerOpen ? (
+                    <AgentContinueMenu
+                      agents={continuableAgents}
+                      selectedIndex={continueSelectedIndex}
+                      onSelect={(agentId) => void handleContinueWithAgent(agentId)}
+                    />
+                  ) : null}
+
                   <SubagentActivity
                     runs={subagentRuns}
                     agents={registryAgents}
@@ -1495,6 +1625,30 @@ export function AgentPanel() {
                           </motion.div>
                         )}
                       </AnimatePresence>
+                      {pendingContinuation ? (
+                        <div
+                          className="relative z-10 mb-1.5 flex flex-wrap items-center gap-1.5"
+                          data-pipper-id="continuation-chip"
+                        >
+                          <span className="inline-flex items-center gap-1.5 rounded-full border border-border bg-surface-2 py-1 pl-2.5 pr-1.5 text-xs text-muted-foreground">
+                            <ChatCircleTextIcon size={13} />
+                            Transcript from previous conversation
+                            <button
+                              type="button"
+                              aria-label="Remove transcript"
+                              data-pipper-id="continuation-chip-remove"
+                              className="inline-flex size-4 items-center justify-center rounded-full text-muted-foreground/70 transition-colors hover:bg-hover hover:text-foreground"
+                              onClick={() => {
+                                if (snapshot?.threadId) {
+                                  useContinuationStore.getState().clearPending(snapshot.threadId);
+                                }
+                              }}
+                            >
+                              <XIcon size={11} />
+                            </button>
+                          </span>
+                        </div>
+                      ) : null}
                       <InputMessage
                         className="relative z-10"
                         textareaRef={composerTextareaRef}
@@ -1531,6 +1685,32 @@ export function AgentPanel() {
                         }
                         textareaProps={{
                           onKeyDown: (event) => {
+                            // `/continue` agent picker owns the keys while open.
+                            if (continuePickerOpen && continuableAgents.length) {
+                              if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+                                event.preventDefault();
+                                setContinueSelectedIndex(
+                                  (current) =>
+                                    (current +
+                                      (event.key === "ArrowDown" ? 1 : -1) +
+                                      continuableAgents.length) %
+                                    continuableAgents.length,
+                                );
+                                return;
+                              }
+                              if (event.key === "Enter" || event.key === "Tab") {
+                                event.preventDefault();
+                                const agent =
+                                  continuableAgents[continueSelectedIndex] ?? continuableAgents[0];
+                                if (agent) void handleContinueWithAgent(agent.id);
+                                return;
+                              }
+                              if (event.key === "Escape") {
+                                event.preventDefault();
+                                setContinuePickerOpen(false);
+                                return;
+                              }
+                            }
                             if (
                               slashMatches.length &&
                               (event.key === "ArrowDown" || event.key === "ArrowUp")
@@ -1740,6 +1920,7 @@ export function AgentPanel() {
                         autoCompactionEnabled={snapshot.autoCompactionEnabled}
                         sessionTokens={snapshot.stats.used}
                         sessionCost={snapshot.stats.cost?.amount}
+                        rateLimit={snapshot.usage?.rateLimit}
                       />
                       {snapshot.stats.cost && snapshot.stats.cost.amount > 0 && (
                         <span className="tabular-nums opacity-70">

--- a/src/components/agent-panel.tsx
+++ b/src/components/agent-panel.tsx
@@ -38,13 +38,14 @@ import { toast } from "@/components/ui/toast";
 import type { AgentPanelSnapshot } from "@/store/agent-store";
 import { useContinuationStore } from "@/store/continuation-store";
 import {
+  budgetTranscript,
   buildContinuationText,
   extractConversation,
-  formatTranscript,
   hasConversation,
   type TranscriptSourceMessage,
 } from "@/lib/acp-transcript";
 import type { ContentBlock } from "../../contracts/acp.ts";
+import { assemblePromptBlocks } from "@/lib/acp-session-reducer";
 import { stringifyMessageContent, type MessageLike } from "@/lib/message-utils";
 import {
   extractGroupedMessageImages,
@@ -57,6 +58,8 @@ import { CONTINUE_COMMAND, matchAgentCommands, mergeAgentCommands } from "@/lib/
 import { isSubagentTrigger, SUBAGENT_COMMAND } from "@/lib/subagent-orchestration";
 import { SubagentComposer, type SubagentComposerSubmit } from "@/components/subagent-composer";
 import { SubagentActivity } from "@/components/subagent-activity";
+/** Max agents shown in (and selectable from) the `/continue` picker. */
+const MAX_CONTINUE_AGENTS = 8;
 const iconButtonClass =
   "inline-flex size-6 items-center justify-center rounded-full  text-muted-foreground/60 hover:text-foreground hover:bg-hover transition-colors duration-100 cursor-pointer outline-none focus-visible:ring-1 focus-visible:ring-ring";
 
@@ -583,9 +586,14 @@ export function AgentPanel() {
     [snapshot?.commands],
   );
   const registryAgents = useAgentRegistryStore((state) => state.agents);
-  // Agents offered by `/continue` — only ones the user can actually connect to.
+  // Agents offered by `/continue` — only ones the user can actually connect to,
+  // bounded to what the picker renders so display and keyboard selection share
+  // one collection (no selecting an off-list, invisible agent).
   const continuableAgents = useMemo(
-    () => registryAgents.filter((agent) => agent.available !== false),
+    () =>
+      registryAgents
+        .filter((agent) => agent.available !== false)
+        .slice(0, MAX_CONTINUE_AGENTS),
     [registryAgents],
   );
   // Carry-over transcript staged for the currently-viewed thread, if any.
@@ -966,14 +974,18 @@ export function AgentPanel() {
             ? sendPrompt({
                 threadId: operationThreadId,
                 message: trimmed,
+                // Lead with the transcript as its own context block, then reuse
+                // the shared block builder for the user's message + images so the
+                // target agent's image capability is honored. Building the image
+                // blocks by hand here would bypass that filter (a supplied
+                // `prompt` short-circuits assemblePromptBlocks in the main path).
                 prompt: [
                   { type: "text", text: buildContinuationText(pendingTranscript) },
-                  ...(trimmed ? [{ type: "text", text: trimmed }] : []),
-                  ...newImages.map((img) => ({
-                    type: "image",
-                    data: img.data,
-                    mimeType: img.mimeType,
-                  })),
+                  ...assemblePromptBlocks({
+                    message: trimmed,
+                    images: newImages,
+                    allowImage: canAttachImage(),
+                  }),
                 ] as ContentBlock[],
                 streamingBehavior: isStreaming ? streamingBehavior : undefined,
               })
@@ -1067,6 +1079,15 @@ export function AgentPanel() {
         setInputValue("");
         return;
       }
+      if (continuableAgents.length === 0) {
+        toast({
+          icon: <WarningIcon className="size-5 text-red-500" />,
+          title: "No agents available",
+          description: "Install or sign in to another agent to continue this conversation.",
+        });
+        setInputValue("");
+        return;
+      }
       setInputValue("");
       setSelectedCommandIndex(0);
       setContinueSelectedIndex(0);
@@ -1115,8 +1136,9 @@ export function AgentPanel() {
         worktreePath,
       );
       // Stage the transcript before selecting the thread so the chip is present
-      // the moment its composer renders.
-      useContinuationStore.getState().setPending(thread.id, formatTranscript(turns));
+      // the moment its composer renders. Bounded to a token budget so a long
+      // source thread can't blow the new thread's context on the first send.
+      useContinuationStore.getState().setPending(thread.id, budgetTranscript(turns).text);
       await loadProjectThreads(projectId, { reset: true });
       await selectThread(thread.id);
     } catch (err) {

--- a/src/components/pipper-overlay.tsx
+++ b/src/components/pipper-overlay.tsx
@@ -412,17 +412,7 @@ export function PipperOverlay() {
             <div className="absolute inset-0 rounded-sm" />
           </BorderBeam>
 
-          {/* "Editing…" label chip */}
-          <div
-            className={cn(
-              "absolute -top-7 left-0 flex items-center gap-1.5 rounded-md px-2 py-1",
-              "text-[11px] font-semibold text-foreground whitespace-nowrap",
-              surfaceClasses(5, 4),
-            )}
-          >
-            <span className="size-1.5 rounded-full bg-foreground animate-pulse" />
-            Editing {highlight.label}…
-          </div>
+
         </div>
       )}
 
@@ -438,8 +428,8 @@ export function PipperOverlay() {
           }}
           onClick={(e) => e.stopPropagation()}
         >
-          <BorderBeam size="pulse-outside" colorVariant="mono">
-            <Elevated offset={4} shadowLevel={5} className="rounded-xl p-1.5">
+          <BorderBeam size="pulse-inner" colorVariant="mono">
+
               <InputMessage
                 value={commentText}
                 onValueChange={setCommentText}
@@ -503,7 +493,7 @@ export function PipperOverlay() {
                 minRows={1}
                 maxRows={4}
               />
-            </Elevated>
+
           </BorderBeam>
         </div>
       )}

--- a/src/index.css
+++ b/src/index.css
@@ -283,17 +283,18 @@
     --pipper-beam-angle: 360deg;
   }
 }
+/* Edit-mode hover outline — uses design-system --ring (neutral gray), not a tinted hue */
 @keyframes pipper-highlight-pulse {
   0%,
   100% {
     opacity: 1;
     box-shadow:
-      0 0 0 1px oklch(0.65 0.2 260 / 0.25),
-      inset 0 0 0 1px oklch(0.65 0.2 260 / 0.1);
+      0 0 0 1px color-mix(in oklch, var(--ring) 45%, transparent),
+      inset 0 0 0 1px color-mix(in oklch, var(--ring) 18%, transparent);
   }
   50% {
     opacity: 0.75;
-    box-shadow: 0 0 0 3px oklch(0.65 0.2 260 / 0.12);
+    box-shadow: 0 0 0 3px color-mix(in oklch, var(--ring) 22%, transparent);
   }
 }
 @keyframes fade-in {

--- a/src/lib/acp-session-reducer.ts
+++ b/src/lib/acp-session-reducer.ts
@@ -265,11 +265,18 @@ export function applySessionUpdate(state: AcpSessionSlice, update: SessionUpdate
       const rateLimitMeta = (update as { _meta?: Record<string, unknown> })._meta?.[
         "_claude/rateLimit"
       ] as Partial<AcpRateLimitInfo> | undefined;
+      // Claude reports utilization as a 0–1 fraction; normalize to a canonical
+      // 0–100 percent here so downstream consumers never have to guess the scale.
+      const rawUtilization = rateLimitMeta?.utilization;
+      const utilization =
+        typeof rawUtilization === "number" && !Number.isNaN(rawUtilization)
+          ? rawUtilization * 100
+          : undefined;
       const rateLimit: AcpUsageState["rateLimit"] = rateLimitMeta
         ? {
             status: rateLimitMeta.status ?? "allowed",
             rateLimitType: rateLimitMeta.rateLimitType,
-            utilization: rateLimitMeta.utilization,
+            utilization,
             resetsAt: rateLimitMeta.resetsAt,
           }
         : (state.usage?.rateLimit ?? null);

--- a/src/lib/acp-session-reducer.ts
+++ b/src/lib/acp-session-reducer.ts
@@ -15,7 +15,12 @@ import type {
   SessionConfigOption,
   SessionUpdate,
 } from "@agentclientprotocol/sdk";
-import type { AcpEntry, AcpToolCallState, AcpUsageState } from "../../contracts/acp.ts";
+import type {
+  AcpEntry,
+  AcpRateLimitInfo,
+  AcpToolCallState,
+  AcpUsageState,
+} from "../../contracts/acp.ts";
 
 export interface AcpSessionSlice {
   entries: AcpEntry[];
@@ -253,12 +258,28 @@ export function applySessionUpdate(state: AcpSessionSlice, update: SessionUpdate
           ? (update as { size: number }).size
           : (state.usage?.size ?? 0);
       const cost = (update as { cost?: AcpUsageState["cost"] }).cost;
+      // Vendor-specific subscription rate limit, when present. The Claude ACP
+      // adapter attaches its `rate_limit_info` here on a `usage_update`. Absent
+      // on ordinary token-usage updates, so preserve the last known value rather
+      // than clearing it every turn; other agents never set it (stays null).
+      const rateLimitMeta = (update as { _meta?: Record<string, unknown> })._meta?.[
+        "_claude/rateLimit"
+      ] as Partial<AcpRateLimitInfo> | undefined;
+      const rateLimit: AcpUsageState["rateLimit"] = rateLimitMeta
+        ? {
+            status: rateLimitMeta.status ?? "allowed",
+            rateLimitType: rateLimitMeta.rateLimitType,
+            utilization: rateLimitMeta.utilization,
+            resetsAt: rateLimitMeta.resetsAt,
+          }
+        : (state.usage?.rateLimit ?? null);
       return {
         ...state,
         usage: {
           used: (update as { used?: number }).used ?? used,
           size,
           cost: cost ?? state.usage?.cost,
+          rateLimit,
         },
         titleChanged: false,
       };

--- a/src/lib/acp-transcript.test.ts
+++ b/src/lib/acp-transcript.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildContinuationText,
+  extractConversation,
+  formatTranscript,
+  hasConversation,
+  type TranscriptSourceMessage,
+} from "./acp-transcript";
+
+describe("extractConversation", () => {
+  it("keeps user and assistant text in order", () => {
+    const messages: TranscriptSourceMessage[] = [
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "hi there" },
+      { role: "user", content: "thanks" },
+    ];
+    expect(extractConversation(messages)).toEqual([
+      { role: "user", text: "hello" },
+      { role: "assistant", text: "hi there" },
+      { role: "user", text: "thanks" },
+    ]);
+  });
+
+  it("drops thoughts and tool calls, keeping only text parts of assistant runs", () => {
+    const messages: TranscriptSourceMessage[] = [
+      { role: "user", content: "run the build" },
+      {
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "let me think about this" },
+          { type: "toolCall", id: "t1", name: "bash" },
+          { type: "text", text: "Done — the build passed." },
+        ],
+      },
+    ];
+    expect(extractConversation(messages)).toEqual([
+      { role: "user", text: "run the build" },
+      { role: "assistant", text: "Done — the build passed." },
+    ]);
+  });
+
+  it("excludes non-conversational roles (toolResult) and empty messages", () => {
+    const messages: TranscriptSourceMessage[] = [
+      { role: "user", content: "  " },
+      { role: "toolResult", content: "exit 0" },
+      { role: "assistant", content: [{ type: "toolCall", id: "t1", name: "bash" }] },
+      { role: "assistant", content: "kept" },
+    ];
+    expect(extractConversation(messages)).toEqual([{ role: "assistant", text: "kept" }]);
+  });
+
+  it("joins multiple text parts within one assistant message", () => {
+    const messages: TranscriptSourceMessage[] = [
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "part one " },
+          { type: "toolCall", id: "t1", name: "bash" },
+          { type: "text", text: "part two" },
+        ],
+      },
+    ];
+    expect(extractConversation(messages)).toEqual([
+      { role: "assistant", text: "part one part two" },
+    ]);
+  });
+});
+
+describe("hasConversation", () => {
+  it("is false when nothing carries over", () => {
+    expect(hasConversation([])).toBe(false);
+    expect(
+      hasConversation([
+        { role: "toolResult", content: "x" },
+        { role: "assistant", content: [{ type: "toolCall", id: "t1", name: "bash" }] },
+      ]),
+    ).toBe(false);
+  });
+
+  it("is true with at least one user/assistant turn", () => {
+    expect(hasConversation([{ role: "user", content: "hi" }])).toBe(true);
+  });
+});
+
+describe("formatTranscript / buildContinuationText", () => {
+  it("labels turns and separates them", () => {
+    const text = formatTranscript([
+      { role: "user", text: "q" },
+      { role: "assistant", text: "a" },
+    ]);
+    expect(text).toBe("User: q\n\nAssistant: a");
+  });
+
+  it("wraps the transcript with a continuation preamble containing the body", () => {
+    const wrapped = buildContinuationText("User: q\n\nAssistant: a");
+    expect(wrapped).toContain("earlier conversation");
+    expect(wrapped).toContain("User: q");
+    expect(wrapped).toContain("Assistant: a");
+  });
+});

--- a/src/lib/acp-transcript.test.ts
+++ b/src/lib/acp-transcript.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from "vitest";
 import {
+  budgetTranscript,
   buildContinuationText,
   extractConversation,
   formatTranscript,
   hasConversation,
   type TranscriptSourceMessage,
+  type TranscriptTurn,
 } from "./acp-transcript";
 
 describe("extractConversation", () => {
@@ -49,19 +51,19 @@ describe("extractConversation", () => {
     expect(extractConversation(messages)).toEqual([{ role: "assistant", text: "kept" }]);
   });
 
-  it("joins multiple text parts within one assistant message", () => {
+  it("separates text parts split by a tool call instead of fusing sentences", () => {
     const messages: TranscriptSourceMessage[] = [
       {
         role: "assistant",
         content: [
-          { type: "text", text: "part one " },
+          { type: "text", text: "I'll check." },
           { type: "toolCall", id: "t1", name: "bash" },
-          { type: "text", text: "part two" },
+          { type: "text", text: "Tests passed." },
         ],
       },
     ];
     expect(extractConversation(messages)).toEqual([
-      { role: "assistant", text: "part one part two" },
+      { role: "assistant", text: "I'll check.\n\nTests passed." },
     ]);
   });
 });
@@ -96,5 +98,41 @@ describe("formatTranscript / buildContinuationText", () => {
     expect(wrapped).toContain("earlier conversation");
     expect(wrapped).toContain("User: q");
     expect(wrapped).toContain("Assistant: a");
+  });
+});
+
+describe("budgetTranscript", () => {
+  it("keeps everything and flags no omission when under budget", () => {
+    const turns: TranscriptTurn[] = [
+      { role: "user", text: "q" },
+      { role: "assistant", text: "a" },
+    ];
+    const result = budgetTranscript(turns, 1_000);
+    expect(result.omittedHistory).toBe(false);
+    expect(result.text).toBe("User: q\n\nAssistant: a");
+  });
+
+  it("drops the oldest turns, keeps the newest, and marks omission", () => {
+    const turns: TranscriptTurn[] = [
+      { role: "user", text: "oldest" },
+      { role: "assistant", text: "middle" },
+      { role: "user", text: "newest" },
+    ];
+    // ~4 chars/token: a 2-token budget (~8 chars) only fits the last turn.
+    const result = budgetTranscript(turns, 2);
+    expect(result.omittedHistory).toBe(true);
+    expect(result.text).toContain("omitted");
+    expect(result.text).toContain("newest");
+    expect(result.text).not.toContain("oldest");
+  });
+
+  it("always keeps at least the most recent turn even if it alone exceeds budget", () => {
+    const turns: TranscriptTurn[] = [
+      { role: "user", text: "old" },
+      { role: "assistant", text: "a very long final answer that exceeds the tiny budget" },
+    ];
+    const result = budgetTranscript(turns, 1);
+    expect(result.text).toContain("a very long final answer");
+    expect(result.omittedHistory).toBe(true);
   });
 });

--- a/src/lib/acp-transcript.ts
+++ b/src/lib/acp-transcript.ts
@@ -18,16 +18,24 @@ export interface TranscriptTurn {
   text: string;
 }
 
-/** Visible text of a message: the string itself, or the joined `text` parts. */
+/**
+ * Visible text of a message: the string itself, or the `text` parts joined.
+ * Assistant runs emit a separate text part on each side of a tool call, so the
+ * parts must be joined with a separator — concatenating with "" would fuse
+ * sentences ("I'll check." + "Tests passed." → "I'll check.Tests passed.").
+ * "\n\n" matches how the app's own projection concatenates visible segments.
+ */
 function messageText(content: TranscriptSourceMessage["content"]): string {
   if (typeof content === "string") return content.trim();
   if (!Array.isArray(content)) return "";
   const parts: string[] = [];
   for (const part of content) {
     const typed = part as { type?: string; text?: string };
-    if (typed.type === "text" && typeof typed.text === "string") parts.push(typed.text);
+    if (typed.type === "text" && typeof typed.text === "string" && typed.text) {
+      parts.push(typed.text);
+    }
   }
-  return parts.join("").trim();
+  return parts.join("\n\n").trim();
 }
 
 /** User/assistant turns with non-empty visible text, in timeline order. */
@@ -54,6 +62,53 @@ export function formatTranscript(turns: readonly TranscriptTurn[]): string {
   return turns
     .map((turn) => `${turn.role === "user" ? "User" : "Assistant"}: ${turn.text}`)
     .join("\n\n");
+}
+
+/** Rough characters-per-token; conversational text averages ~4. */
+const CHARS_PER_TOKEN = 4;
+
+/**
+ * Target token budget for a carried-over transcript. Deliberately conservative
+ * so a long source thread can't swallow the new thread's whole context window
+ * on the very first message.
+ */
+export const CONTINUATION_TOKEN_BUDGET = 12_000;
+
+export interface BudgetedTranscript {
+  /** Transcript text, trimmed to the newest turns that fit the budget. */
+  text: string;
+  /** True when older turns were dropped to fit. */
+  omittedHistory: boolean;
+}
+
+/**
+ * Format a transcript bounded to a token budget: keep the newest turns that
+ * fit (a conversation is most useful from its tail), drop older ones, and — when
+ * anything was dropped — prepend a marker so the receiving agent knows earlier
+ * history is missing rather than assuming it has the full thread.
+ */
+export function budgetTranscript(
+  turns: readonly TranscriptTurn[],
+  tokenBudget: number = CONTINUATION_TOKEN_BUDGET,
+): BudgetedTranscript {
+  const charBudget = Math.max(0, tokenBudget) * CHARS_PER_TOKEN;
+  const kept: TranscriptTurn[] = [];
+  let total = 0;
+  // Walk newest → oldest, keeping turns until the next one would overflow.
+  // Always keep at least the most recent turn, even if it alone exceeds budget.
+  for (let i = turns.length - 1; i >= 0; i -= 1) {
+    const turn = turns[i]!;
+    const cost = turn.text.length + turn.role.length + 4; // + framing overhead
+    if (kept.length > 0 && total + cost > charBudget) break;
+    kept.unshift(turn);
+    total += cost;
+  }
+  const omittedHistory = kept.length < turns.length;
+  const body = formatTranscript(kept);
+  const text = omittedHistory
+    ? `[Earlier messages were omitted to fit the context window.]\n\n${body}`
+    : body;
+  return { text, omittedHistory };
 }
 
 /**

--- a/src/lib/acp-transcript.ts
+++ b/src/lib/acp-transcript.ts
@@ -1,0 +1,73 @@
+/**
+ * Extract a plain user/assistant transcript from panel messages, for the
+ * `/continue` flow (fork a conversation onto another agent). Thoughts and tool
+ * calls are intentionally dropped — only what the two parties actually said.
+ *
+ * Operates on the panel snapshot's message shape (already role-grouped) so it
+ * needs no access to the raw ACP entry timeline and stays trivially testable.
+ */
+
+/** Minimal shape shared with `AgentPanelSnapshot["messages"]`. */
+export interface TranscriptSourceMessage {
+  role: string;
+  content: string | Array<Record<string, unknown>>;
+}
+
+export interface TranscriptTurn {
+  role: "user" | "assistant";
+  text: string;
+}
+
+/** Visible text of a message: the string itself, or the joined `text` parts. */
+function messageText(content: TranscriptSourceMessage["content"]): string {
+  if (typeof content === "string") return content.trim();
+  if (!Array.isArray(content)) return "";
+  const parts: string[] = [];
+  for (const part of content) {
+    const typed = part as { type?: string; text?: string };
+    if (typed.type === "text" && typeof typed.text === "string") parts.push(typed.text);
+  }
+  return parts.join("").trim();
+}
+
+/** User/assistant turns with non-empty visible text, in timeline order. */
+export function extractConversation(
+  messages: readonly TranscriptSourceMessage[],
+): TranscriptTurn[] {
+  const turns: TranscriptTurn[] = [];
+  for (const message of messages) {
+    if (message.role !== "user" && message.role !== "assistant") continue;
+    const text = messageText(message.content);
+    if (!text) continue;
+    turns.push({ role: message.role, text });
+  }
+  return turns;
+}
+
+/** True when there is at least one user/assistant turn worth carrying over. */
+export function hasConversation(messages: readonly TranscriptSourceMessage[]): boolean {
+  return extractConversation(messages).length > 0;
+}
+
+/** Render turns as a readable `User:` / `Assistant:` transcript. */
+export function formatTranscript(turns: readonly TranscriptTurn[]): string {
+  return turns
+    .map((turn) => `${turn.role === "user" ? "User" : "Assistant"}: ${turn.text}`)
+    .join("\n\n");
+}
+
+/**
+ * Wrap a transcript with a short preamble so the receiving agent treats it as
+ * prior context to continue, not as a fresh instruction. Sent as its own
+ * content block alongside the user's actual message.
+ */
+export function buildContinuationText(transcript: string): string {
+  return [
+    "The following is a transcript of an earlier conversation you are continuing.",
+    "Use it as context and pick up seamlessly from where it left off.",
+    "",
+    transcript,
+    "",
+    "--- end of earlier conversation ---",
+  ].join("\n");
+}

--- a/src/lib/agent-commands.ts
+++ b/src/lib/agent-commands.ts
@@ -8,11 +8,20 @@ export interface AgentCommand {
   source: "agent" | "client";
 }
 
+/** Client command: fork this conversation onto another agent. */
+export const CONTINUE_COMMAND = "continue";
+
 /** Commands the composer handles itself — never forwarded to the agent. */
 export const CLIENT_COMMANDS: AgentCommand[] = [
   {
     name: SUBAGENT_COMMAND,
     description: "Orchestrate subagents across your installed agents",
+    inputHint: null,
+    source: "client",
+  },
+  {
+    name: CONTINUE_COMMAND,
+    description: "Continue this conversation with another agent",
     inputHint: null,
     source: "client",
   },

--- a/src/store/continuation-store.ts
+++ b/src/store/continuation-store.ts
@@ -1,0 +1,31 @@
+import { create } from "zustand";
+
+/**
+ * Holds the carry-over transcript for a `/continue`-created thread until the
+ * user sends their first message (or dismisses it). Keyed by the new thread's
+ * id. In-memory only: an abandoned continuation simply reopens as an ordinary
+ * empty thread after a restart. Cleared on send, chip dismissal, and thread
+ * deletion so no stale entry survives.
+ */
+interface ContinuationState {
+  pendingByThreadId: Record<string, string>;
+  setPending: (threadId: string, transcript: string) => void;
+  clearPending: (threadId: string) => void;
+  getPending: (threadId: string) => string | null;
+}
+
+export const useContinuationStore = create<ContinuationState>((set, get) => ({
+  pendingByThreadId: {},
+  setPending: (threadId, transcript) =>
+    set((state) => ({
+      pendingByThreadId: { ...state.pendingByThreadId, [threadId]: transcript },
+    })),
+  clearPending: (threadId) =>
+    set((state) => {
+      if (!(threadId in state.pendingByThreadId)) return state;
+      const next = { ...state.pendingByThreadId };
+      delete next[threadId];
+      return { pendingByThreadId: next };
+    }),
+  getPending: (threadId) => get().pendingByThreadId[threadId] ?? null,
+}));

--- a/src/store/thread-store.ts
+++ b/src/store/thread-store.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
 import type { Thread } from "../../contracts/threads.ts";
+import { useContinuationStore } from "@/store/continuation-store";
 
 const THREAD_PAGE_SIZE = 10;
 
@@ -129,6 +130,8 @@ export const useThreadStore = create<ThreadState>((set, get) => ({
     const existingThread = get().threads.find((thread) => thread.id === id);
     try {
       await window.omni.threads.delete(id);
+      // Drop any unsent `/continue` transcript staged for this thread.
+      useContinuationStore.getState().clearPending(id);
       set((state) => ({
         threads: state.threads.filter((t) => t.id !== id),
         pagesByProject: existingThread


### PR DESCRIPTION
feat : general improvements

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `/continue` to carry a conversation transcript into a new thread with another available agent.
  * Added an agent picker with keyboard navigation and reduced-motion support.
  * Added subscription rate-limit details, including remaining usage and reset timing, to context usage indicators.

* **UI Improvements**
  * Updated comment popup styling and highlight animations.
  * Removed the auto-compaction detail from context usage information.

* **Bug Fixes**
  * Preserved rate-limit information across usage updates when new rate-limit data is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR ships two features: a `/continue` command that forks the current conversation onto another agent (snapshotting and budgeting the transcript as a carry-over chip), and subscription rate-limit details in the context-usage popover (label, percent remaining, reset countdown). It also tightens the highlight-pulse animation colors to use the design system's `--ring` token and removes the "Editing…" label chip.

- **`/continue` flow**: `extractConversation` strips thoughts and tool calls, `budgetTranscript` trims to the newest 12k-token slice, the result is staged in a Zustand store keyed by thread id, and consumed (then cleared) on the user's first send in the new thread. Keyboard navigation is capped to `continuableAgents` (already sliced to `MAX_CONTINUE_AGENTS = 8`), which fixes the prior off-list-selection bug.
- **Rate-limit panel**: Normalisation from Claude's 0–1 fraction to 0–100% happens once at the reducer boundary; downstream helpers clamp and display cleanly. The `formatRateLimitReset` function is missing the same `Number.isNaN` guard that `rateLimitPercentLeft` has, and the `showSession` gate still includes the `sessionTokens` branch even though that row was removed.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the two new features are well-scoped, the transcript utility has solid test coverage, and the keyboard-navigation fix is correct.

The `/continue` flow is implemented carefully: transcript extraction is pure and tested, the token budget is conservative, and the continuation store cleans up on send, chip dismissal, and thread deletion. The rate-limit panel normalises at one boundary and clamps everywhere else. The two gaps (`formatRateLimitReset` missing NaN guard, stale `showSession` condition) have negligible real-world impact.

`@/components/ui/context-window-ring.tsx` — two small fixes suggested for the `formatRateLimitReset` NaN guard and the stale `showSession` condition.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| @/components/ui/context-window-ring.tsx | Adds rate-limit section (label, percent-left, reset countdown) to the context-usage popover; `formatRateLimitReset` is missing a `Number.isNaN` guard (unlike the symmetric `rateLimitPercentLeft`), and `showSession` still includes the `sessionTokens` branch even though the token row was removed. |
| contracts/acp.ts | Adds `AcpRateLimitInfo` interface and optional `rateLimit` field to `AcpUsageState`; clean, well-documented additions. |
| src/components/agent-continue-menu.tsx | New agent picker for `/continue`; clean animated component with reduced-motion support, receives already-sliced agent list from the parent. |
| src/components/agent-panel.tsx | Adds full `/continue` flow: picker state, keyboard navigation, transcript staging, and optimistic chip; `continuableAgents` is pre-sliced to `MAX_CONTINUE_AGENTS` before being used for both rendering and modulo, fixing the previous wrapping bug. |
| src/lib/acp-session-reducer.ts | Normalises Claude's 0–1 `utilization` fraction to 0–100 at the reducer boundary (with a NaN guard), and preserves the last known rate-limit across turns where the field is absent. |
| src/lib/acp-transcript.ts | New utility that extracts user/assistant turns, drops thoughts/tool-calls, and applies a token budget (newest-first) for the `/continue` transcript payload. |
| src/lib/acp-transcript.test.ts | Thorough test suite covering extraction, filtering, budgeting (including the always-keep-last-turn edge case), and the continuation preamble wrapper. |
| src/store/continuation-store.ts | Simple Zustand store keyed by thread id; correct optimistic-clear semantics, cleaned up on thread deletion in `thread-store.ts`. |
| src/components/pipper-overlay.tsx | Removes the "Editing…" chip and switches the comment popup `BorderBeam` to `pulse-inner`; intentional UI refinement. |
| src/lib/agent-commands.ts | Adds the `/continue` client command constant and its `CLIENT_COMMANDS` entry. |
| src/index.css | Replaces hardcoded `oklch(0.65 0.2 260 / …)` in the highlight pulse animation with `color-mix(in oklch, var(--ring) …)` for proper dark-mode theming. |
| src/store/thread-store.ts | Clears the continuation store on thread deletion to prevent stale transcripts from accumulating. |


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `@/components/ui/context-window-ring.tsx`, line 118-129 ([link](https://github.com/maker-or/omni/blob/0f16f3c53102a747a51149761cbd1ac15b5d87ad/@/components/ui/context-window-ring.tsx#L118-L129)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Commented-out "Auto-compaction" row left in production code**

   The auto-compaction `<dl>` entry is wrapped in `{/* ... */}` rather than being deleted or feature-flagged. A JSX block comment in the middle of render output means the feature is silently gone — the prop `autoCompactionEnabled` is still threaded all the way through `ContextWindowRingProps` → `ContextUsagePanelProps` but has no observable effect. If this is a deliberate removal, the prop and associated logic should be cleaned up; if it's temporary scaffolding, a TODO or feature-flag is clearer than a comment-out.
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["ok i"](https://github.com/maker-or/omni/commit/310c7c2807df2763f8c8d3decdafcf269f8f2d84) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45285220)</sub>

<!-- /greptile_comment -->