### PR TITLE
Phone PWA: final-report text, chat view, background threads

### DIFF
--- a/contracts/remote.ts
+++ b/contracts/remote.ts
@@ -26,6 +26,11 @@ export interface RemoteReport {
   threadId: string;
   running: boolean;
   summary: string | null;
+  /** Accumulated agent reply text (no tool calls) — shown whole at the end. */
+  finalText: string | null;
+  messages: Array<{ role: "user" | "agent"; text: string }>;
+  /** Project display name, so a wrong-project thread is obvious on the phone. */
+  projectName: string | null;
   filesTouched: string[];
   worktreePath: string | null;
   /** False when worktree creation failed and the task ran in project root. */

--- a/electron/agent-connection-manager.ts
+++ b/electron/agent-connection-manager.ts
@@ -867,6 +867,39 @@ export class AgentConnectionManager {
     return this.resolveThreadCwd(thread.worktree_path, project.path);
   }
 
+  /** Text-only transcript for the phone PWA: no tool calls, no streaming.
+   * Returns accumulated agent_text + user_text so the phone can show the
+   * entire final message at once when the turn ends. Falls back to the
+   * persisted snapshot when the thread is not resident in memory. */
+  getThreadTranscript(threadId: string): {
+    finalText: string | null;
+    messages: Array<{ role: "user" | "agent"; text: string }>;
+  } {
+    const runtime = this.sessions.get(threadId);
+    const entries =
+      runtime?.slice.entries ??
+      (() => {
+        try {
+          const thread = getThread(threadId);
+          if (!thread) return [];
+          return this.snapshotStore.load(thread)?.slice.entries ?? [];
+        } catch {
+          return [];
+        }
+      })();
+    const messages: Array<{ role: "user" | "agent"; text: string }> = [];
+    for (const e of entries) {
+      if (e.type === "agent_text" && e.text.trim()) messages.push({ role: "agent", text: e.text });
+      else if (e.type === "user_text" && e.text.trim())
+        messages.push({ role: "user", text: e.text });
+    }
+    const agentTexts = messages.filter((m) => m.role === "agent").map((m) => m.text);
+    const joined = agentTexts.join("\n\n").trim();
+    // Cap payload for the phone poll; desktop keeps full history.
+    const finalText = joined ? joined.slice(-20000) : null;
+    return { finalText, messages: messages.slice(-50) };
+  }
+
   /** Clear the live view when the user closes the last open thread tab. */
   async clearActiveThread(): Promise<void> {
     this.activeThreadId = null;
@@ -2222,6 +2255,7 @@ export class AgentConnectionManager {
     agentId?: string | null,
     worktreePath?: string | null,
     initialModelId?: string | null,
+    opts?: { background?: boolean },
   ): Promise<Thread> {
     return this.enqueueThreadActivation(() =>
       this.createThreadInternal(
@@ -2231,6 +2265,7 @@ export class AgentConnectionManager {
         agentId,
         worktreePath,
         initialModelId,
+        opts,
       ),
     );
   }
@@ -2242,6 +2277,7 @@ export class AgentConnectionManager {
     agentId?: string | null,
     worktreePath?: string | null,
     initialModelId?: string | null,
+    opts?: { background?: boolean },
   ): Promise<Thread> {
     const project = getProject(projectId);
     if (!project) throw new Error(`Project not found: ${projectId}`);
@@ -2302,33 +2338,50 @@ export class AgentConnectionManager {
     });
 
     const projectChanged = this.activeProjectId !== projectId;
-    this.activeProjectId = projectId;
-    this.activeThreadId = thread.id;
-    this.publishActiveAgentContext(live.agentId);
-    setActiveProjectId(projectId);
-    // Creating a thread for another project (tab-bar dropdown) is a project
-    // switch: without this broadcast the renderer's project store — and with
-    // it the header's project name, workspace, and branch — keeps showing
-    // the previous project while the agent panel already follows the new one.
-    if (projectChanged) this.broadcastActiveProject?.(projectId);
-    touchThread(thread.id);
+    // Background (phone) threads must never steal desktop focus: skip the
+    // active-thread switch, workspace mirror, and launch selection so the
+    // desktop keeps showing whatever the user already had open.
+    if (opts?.background) {
+      this.emitRunningThreads();
+    } else {
+      this.activeProjectId = projectId;
+      this.activeThreadId = thread.id;
+      this.publishActiveAgentContext(live.agentId);
+      setActiveProjectId(projectId);
+      // Creating a thread for another project (tab-bar dropdown) is a project
+      // switch: without this broadcast the renderer's project store — and with
+      // it the header's project name, workspace, and branch — keeps showing
+      // the previous project while the agent panel already follows the new one.
+      if (projectChanged) this.broadcastActiveProject?.(projectId);
+      touchThread(thread.id);
 
-    this.captureAnalytics?.("thread_created", {
-      project_id: projectId,
-      thread_id: thread.id,
-      agent_id: live.agentId,
-      agent_name: getAgentDescriptor(live.agentId)?.name,
-      is_main: boundWorktree === null,
-    } as AnalyticsProperties);
+      this.captureAnalytics?.("thread_created", {
+        project_id: projectId,
+        thread_id: thread.id,
+        agent_id: live.agentId,
+        agent_name: getAgentDescriptor(live.agentId)?.name,
+        is_main: boundWorktree === null,
+      } as AnalyticsProperties);
 
-    // Same publish-before-persist ordering as switches: the new thread's view
-    // renders immediately while the durable selections settle below.
-    this.pushState(thread.id);
-    const selectionsSettled = Promise.all([
-      updateWorkspaceSelection(projectId, cwd),
-      updateLaunchSelection({ projectId, threadId: thread.id }),
-    ]);
-    await selectionsSettled;
+      // Same publish-before-persist ordering as switches: the new thread's view
+      // renders immediately while the durable selections settle below.
+      this.pushState(thread.id);
+      const selectionsSettled = Promise.all([
+        updateWorkspaceSelection(projectId, cwd),
+        updateLaunchSelection({ projectId, threadId: thread.id }),
+      ]);
+      await selectionsSettled;
+    }
+    if (opts?.background) {
+      touchThread(thread.id);
+      this.captureAnalytics?.("thread_created", {
+        project_id: projectId,
+        thread_id: thread.id,
+        agent_id: live.agentId,
+        agent_name: getAgentDescriptor(live.agentId)?.name,
+        is_main: boundWorktree === null,
+      } as AnalyticsProperties);
+    }
 
     // Seed model after the session exists so the first prompt lands on the
     // user's chosen model. Best-effort: a failed seed still leaves a usable thread.
@@ -2555,6 +2608,9 @@ export class AgentConnectionManager {
       blocks,
       streamingBehavior: input.streamingBehavior,
     });
+    console.log(
+      `[sendPrompt] thread=${threadId} project=${runtime.projectId} cwd=${runtime.cwd} session=${runtime.agentSessionId.slice(0, 8)} msg=${(input.message ?? "").slice(0, 80)}`,
+    );
     this.drainPromptQueue(runtime, live);
     await queued;
   }

--- a/electron/agent-connection-manager.ts
+++ b/electron/agent-connection-manager.ts
@@ -887,16 +887,43 @@ export class AgentConnectionManager {
           return [];
         }
       })();
+    const streaming = runtime?.slice.isStreaming ?? false;
     const messages: Array<{ role: "user" | "agent"; text: string }> = [];
     for (const e of entries) {
       if (e.type === "agent_text" && e.text.trim()) messages.push({ role: "agent", text: e.text });
       else if (e.type === "user_text" && e.text.trim())
         messages.push({ role: "user", text: e.text });
     }
+    if (streaming) {
+      // No-stream contract: agent text after the last user message belongs to
+      // the in-progress turn — hold it back until the turn settles. Completed
+      // turns (agent text followed by a later user message) still show.
+      const lastUser = messages.map((m) => m.role).lastIndexOf("user");
+      if (lastUser >= 0) {
+        for (let i = messages.length - 1; i > lastUser; i--) {
+          if (messages[i]?.role === "agent") messages.splice(i, 1);
+        }
+      } else {
+        for (let i = messages.length - 1; i >= 0; i--) {
+          if (messages[i]?.role === "agent") messages.splice(i, 1);
+        }
+      }
+    }
+    // Total character budget across messages (not just entry count — one
+    // agent entry can hold a whole concatenated reply). Trim oldest first,
+    // always keeping the tail so recent context survives.
+    const MESSAGE_BUDGET = 16000;
+    let total = messages.reduce((n, m) => n + m.text.length, 0);
+    while (messages.length > 1 && total > MESSAGE_BUDGET) {
+      total -= messages.shift()?.text.length ?? 0;
+    }
+    if (messages[0] && total > MESSAGE_BUDGET) {
+      messages[0] = { ...messages[0], text: `…${messages[0].text.slice(-MESSAGE_BUDGET)}` };
+    }
     const agentTexts = messages.filter((m) => m.role === "agent").map((m) => m.text);
     const joined = agentTexts.join("\n\n").trim();
     // Cap payload for the phone poll; desktop keeps full history.
-    const finalText = joined ? joined.slice(-20000) : null;
+    const finalText = joined ? joined.slice(-8000) : null;
     return { finalText, messages: messages.slice(-50) };
   }
 
@@ -2288,7 +2315,12 @@ export class AgentConnectionManager {
     const boundWorktree = cwd === project.path ? null : cwd;
 
     const targetAgentId = agentId ?? this.preferredAgentId;
-    const live = await this.ensureConnection(targetAgentId);
+    // Background creation must not flip the desktop-active agent: spawning
+    // via ensureConnection would switchAgent + preferredAgentId when the
+    // phone picks a different agent. acquireConnection spawns detached.
+    const live = opts?.background
+      ? await this.acquireConnection(targetAgentId)
+      : await this.ensureConnection(targetAgentId);
     const created = await this.sessionNew(live, cwd);
     this.registerWorkspaceRoot(created.sessionId, cwd);
 
@@ -2385,7 +2417,9 @@ export class AgentConnectionManager {
 
     // Seed model after the session exists so the first prompt lands on the
     // user's chosen model. Best-effort: a failed seed still leaves a usable thread.
-    if (initialModelId) {
+    // Skipped for background threads: setConfigOption targets the active
+    // thread, so seeding here would hit the desktop's thread, not this one.
+    if (initialModelId && !opts?.background) {
       try {
         const modelOpt = created.configOptions.find(
           (option) => option.id === "model" || option.category === "model",
@@ -2530,17 +2564,22 @@ export class AgentConnectionManager {
     return thread;
   }
 
-  async sendPrompt(input: AcpPromptInput): Promise<void> {
-    return this.sendPromptInternal(input, true);
+  async sendPrompt(input: AcpPromptInput, opts?: { background?: boolean }): Promise<void> {
+    return this.sendPromptInternal(input, true, opts);
   }
 
   private async sendPromptInternal(
     input: AcpPromptInput,
     appendUserMessage: boolean,
+    opts?: { background?: boolean },
   ): Promise<void> {
     const threadId = input.threadId ?? this.activeThreadId;
     if (!threadId) throw new Error("No active thread");
     if (!this.sessions.has(threadId)) {
+      // Background senders (phone) must not leave desktop focus behind on a
+      // restored thread: remember the active thread and put it back after.
+      const prevThreadId = opts?.background ? this.activeThreadId : null;
+      const prevProjectId = opts?.background ? this.activeProjectId : null;
       try {
         await this.switchThread(threadId);
       } catch (err) {
@@ -2548,6 +2587,20 @@ export class AgentConnectionManager {
         // winner has finished by now, so one retry runs unqueued and fast.
         if (!isActivationSuperseded(err)) throw err;
         await this.switchThread(threadId);
+      } finally {
+        if (opts?.background && prevThreadId !== threadId) {
+          this.activeThreadId = prevThreadId;
+          this.activeProjectId = prevProjectId;
+          if (prevProjectId) setActiveProjectId(prevProjectId);
+          if (prevThreadId) {
+            await updateLaunchSelection({
+              projectId: prevProjectId!,
+              threadId: prevThreadId,
+            }).catch(() => undefined);
+            this.pushState(prevThreadId);
+          }
+          this.emitRunningThreads();
+        }
       }
     }
     let runtime = this.sessions.get(threadId);
@@ -2609,7 +2662,7 @@ export class AgentConnectionManager {
       streamingBehavior: input.streamingBehavior,
     });
     console.log(
-      `[sendPrompt] thread=${threadId} project=${runtime.projectId} cwd=${runtime.cwd} session=${runtime.agentSessionId.slice(0, 8)} msg=${(input.message ?? "").slice(0, 80)}`,
+      `[sendPrompt] thread=${threadId} project=${runtime.projectId} cwd=${runtime.cwd} session=${runtime.agentSessionId.slice(0, 8)} msgLen=${(input.message ?? "").length} images=${input.images?.length ?? 0}`,
     );
     this.drainPromptQueue(runtime, live);
     await queued;

--- a/electron/remote-server.ts
+++ b/electron/remote-server.ts
@@ -343,19 +343,25 @@ export class RemoteServer {
         let worktreeBranch: string | null = null;
         let isolationNote: string | null = null;
         try {
-          const base =
-            `phone-${body.prompt
-              .slice(0, 24)
-              .toLowerCase()
-              .replace(/[^a-z0-9]+/g, "-")
-              .replace(/^-+|-+$/g, "")}`.slice(0, 36) || "phone-task";
-          // Unique per request: same prompt sent twice must not collide.
-          const slug = `${base}-${Date.now().toString(36)}`;
-          const created = createWorktree({
-            projectPath: project.path,
-            projectId: project.id,
-            name: slug,
-          });
+          // Fixed-length random name: never derived from the prompt text, so
+          // long/unicode/identical prompts can't produce ugly, colliding, or
+          // confusing worktree + branch names. `phone-` prefix keeps the
+          // origin identifiable in `git worktree list`.
+          let created = null;
+          let lastError: unknown = null;
+          for (let attempt = 0; attempt < 5 && !created; attempt++) {
+            const slug = `phone-${randomBytes(4).toString("hex")}`;
+            try {
+              created = createWorktree({
+                projectPath: project.path,
+                projectId: project.id,
+                name: slug,
+              });
+            } catch (err) {
+              lastError = err;
+            }
+          }
+          if (!created) throw lastError ?? new Error("worktree creation failed");
           worktreePath = created.path;
           worktreeBranch = created.branch;
           console.log(`[Remote] worktree created: ${worktreePath}`);
@@ -378,6 +384,7 @@ export class RemoteServer {
             body.modelId ?? null,
             worktreePath,
             null,
+            { background: true },
           );
           try {
             await am.sendPrompt({ threadId: thread.id, message: body.prompt });
@@ -388,7 +395,15 @@ export class RemoteServer {
             throw promptError;
           }
           if (isolationNote) this.isolationNotes.set(thread.id, isolationNote);
-          console.log(`[Remote] prompt sent thread=${thread.id}`);
+          console.log(
+            `[Remote] prompt sent thread=${thread.id} boundWorktree=${thread.worktree_path ?? "<root-fallback>"}`,
+          );
+          if (!thread.worktree_path) {
+            console.warn(
+              `[Remote] thread=${thread.id} running on PROJECT ROOT (no isolated workspace). ` +
+                `requested=${worktreePath ?? "<none: create failed>"} reason=${isolationNote ?? "worktree rejected as not-live"}`,
+            );
+          }
           return send(res, 201, {
             thread: {
               id: thread.id,
@@ -425,10 +440,14 @@ export class RemoteServer {
         if (!thread) return send(res, 404, { error: "Thread not found" });
         const running = (am?.getRunningThreadIds() ?? []).includes(thread.id);
         const cwd = thread.worktree_path ?? getProject(thread.project_id)?.path ?? null;
+        const transcript = am?.getThreadTranscript(thread.id) ?? { finalText: null, messages: [] };
         const report: RemoteReport = {
           threadId: thread.id,
           running,
           summary: thread.title,
+          finalText: transcript.finalText,
+          messages: transcript.messages,
+          projectName: getProject(thread.project_id)?.name ?? thread.project_id,
           filesTouched: await filesTouched(cwd),
           worktreePath: thread.worktree_path ?? null,
           isolated: Boolean(thread.worktree_path),

--- a/electron/remote-server.ts
+++ b/electron/remote-server.ts
@@ -43,10 +43,16 @@ function send(
   status: number,
   body: unknown,
   contentType = "application/json",
+  headers: Record<string, string> = {},
 ): void {
   const text = typeof body === "string" ? body : JSON.stringify(body);
-  res.writeHead(status, { "Content-Type": contentType });
+  res.writeHead(status, { "Content-Type": contentType, ...headers });
   res.end(text);
+}
+
+/** Transcripts must never sit in a browser/proxy cache: always no-store. */
+function sendReport(res: http.ServerResponse, body: unknown): void {
+  send(res, 200, body, "application/json", { "Cache-Control": "no-store" });
 }
 
 function loadOrCreateToken(deps: RemoteServerDeps): string {
@@ -96,6 +102,18 @@ async function filesTouched(cwd: string | null): Promise<string[]> {
   } catch {
     return [];
   }
+}
+
+/** True for loopback or Tailscale (100.64/10) hosts — the only cleartext-safe binds. */
+function isTrustedRemoteHost(host: string): boolean {
+  const h = host.toLowerCase();
+  return (
+    h === "localhost" ||
+    h === "127.0.0.1" ||
+    h === "::1" ||
+    h === "[::1]" ||
+    /^100\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.test(h)
+  );
 }
 
 /** How long after the last authed phone request an idle phone keeps standby. */
@@ -156,7 +174,8 @@ export class RemoteServer {
    * instead of a LAN address we don't serve.
    */
   getAdvertisedHost(): string | null {
-    if (process.env.PIPPER_REMOTE_HOST?.trim()) return process.env.PIPPER_REMOTE_HOST.trim();
+    const override = process.env.PIPPER_REMOTE_HOST?.trim();
+    if (override) return isTrustedRemoteHost(override) ? override : null;
     return this.getTailscaleIps()[0] ?? null;
   }
 
@@ -183,8 +202,17 @@ export class RemoteServer {
     // Tailscale only, so bearer credentials traverse either localhost or the
     // WireGuard-encrypted tailnet — never LAN/Wi-Fi in cleartext. TLS would
     // add self-signed cert friction on the phone with no transport gain.
+    // A PIPPER_REMOTE_HOST override is honored only for loopback/Tailscale —
+    // a LAN address would leak the bearer token + transcripts in cleartext.
     const override = process.env.PIPPER_REMOTE_HOST?.trim();
-    const hosts = override ? [override] : ["127.0.0.1", ...this.getTailscaleIps()];
+    const hosts = override
+      ? isTrustedRemoteHost(override)
+        ? [override]
+        : (() => {
+            console.warn(`[Remote] ignoring untrusted PIPPER_REMOTE_HOST=${override}`);
+            return ["127.0.0.1", ...this.getTailscaleIps()];
+          })()
+      : ["127.0.0.1", ...this.getTailscaleIps()];
     for (const host of new Set(hosts)) {
       const server = http.createServer(handler);
       // A failed bind (port taken, interface gone) must not poison start():
@@ -370,7 +398,7 @@ export class RemoteServer {
           console.warn(`[Remote] worktree fallback to project root: ${isolationNote}`);
         }
         console.log(
-          `[Remote] new phone thread project=${project.id} worktree=${worktreePath ?? "<root>"} prompt=${body.prompt.slice(0, 120)}`,
+          `[Remote] new phone thread project=${project.id} worktree=${worktreePath ?? "<root>"} promptLen=${body.prompt.length}`,
         );
         // modelId from the phone is an *agent* id (listRegisteredAgents).
         // Use it to pick the connection, but never as a model name — the
@@ -386,17 +414,9 @@ export class RemoteServer {
             null,
             { background: true },
           );
-          try {
-            await am.sendPrompt({ threadId: thread.id, message: body.prompt });
-          } catch (promptError) {
-            // Thread + worktree both exist: keep them so the chat is retryable
-            // from the phone instead of dangling. Only report the failure.
-            console.error(`[Remote] prompt failed, keeping thread=${thread.id}:`, promptError);
-            throw promptError;
-          }
           if (isolationNote) this.isolationNotes.set(thread.id, isolationNote);
           console.log(
-            `[Remote] prompt sent thread=${thread.id} boundWorktree=${thread.worktree_path ?? "<root-fallback>"}`,
+            `[Remote] prompt accepted thread=${thread.id} boundWorktree=${thread.worktree_path ?? "<root-fallback>"}`,
           );
           if (!thread.worktree_path) {
             console.warn(
@@ -404,6 +424,17 @@ export class RemoteServer {
                 `requested=${worktreePath ?? "<none: create failed>"} reason=${isolationNote ?? "worktree rejected as not-live"}`,
             );
           }
+          // Respond before the turn runs so the phone shows progress
+          // immediately; the turn streams into the thread in the background
+          // and the report poll picks it up. A prompt failure is logged
+          // server-side — the phone sees an idle thread with no reply.
+          const prompt = body.prompt;
+          void am
+            .sendPrompt({ threadId: thread.id, message: prompt }, { background: true })
+            .then(() => console.log(`[Remote] turn completed thread=${thread.id}`))
+            .catch((promptError) => {
+              console.error(`[Remote] prompt failed, keeping thread=${thread.id}:`, promptError);
+            });
           return send(res, 201, {
             thread: {
               id: thread.id,
@@ -431,7 +462,7 @@ export class RemoteServer {
         if (!thread) return send(res, 404, { error: "Thread not found" });
         const body = JSON.parse((await readBody(req)) || "{}") as { prompt?: string };
         if (!body.prompt?.trim()) return send(res, 400, { error: "prompt is required" });
-        await am.sendPrompt({ threadId: thread.id, message: body.prompt });
+        await am.sendPrompt({ threadId: thread.id, message: body.prompt }, { background: true });
         return send(res, 200, { ok: true });
       }
       const reportMatch = path.match(/^\/api\/remote\/threads\/([^/]+)\/report$/);
@@ -453,7 +484,7 @@ export class RemoteServer {
           isolated: Boolean(thread.worktree_path),
           isolationNote: this.isolationNotes.get(thread.id) ?? null,
         };
-        return send(res, 200, { report });
+        return sendReport(res, { report });
       }
       send(res, 404, { error: "Not found" });
     } catch (error) {

--- a/src/remote/App.tsx
+++ b/src/remote/App.tsx
@@ -44,9 +44,14 @@ export function RemoteApp() {
   const [scanError, setScanError] = useState<string | null>(null);
   const [sendError, setSendError] = useState<string | null>(null);
   const [sending, setSending] = useState(false);
-  // Optimistic follow-up: shown instantly as "Sending…" until the next
-  // report poll confirms it (server messages include it once appended).
-  const [pending, setPending] = useState<string | null>(null);
+  // Optimistic follow-up, scoped to its thread: `known` counts how many
+  // identical user messages the report already had at send time, so a repeat
+  // of an earlier message can't be "confirmed" by the old entry, and a fast
+  // agent reply after the user entry still confirms (match anywhere, not tail).
+  const [pending, setPending] = useState<{ text: string; threadId: string; known: number } | null>(
+    null,
+  );
+  const [reportError, setReportError] = useState<string | null>(null);
   const bottomRef = useRef<HTMLDivElement>(null);
   const bodyRef = useRef<HTMLDivElement>(null);
   // Signature of the visible chat: scroll only when this actually changes,
@@ -100,17 +105,33 @@ export function RemoteApp() {
   useEffect(() => {
     if (!activeId || !paired) return;
     // Poll while open so Running → Done + final text arrives with no stream.
+    // Single-flight + generation: overlapping polls (each waits on a git
+    // subprocess) must not regress the UI — only the newest wins, and a
+    // failed poll keeps the last good report instead of blanking to Loading.
     const wanted = activeId;
     let cancelled = false;
+    let generation = 0;
+    let inflight = false;
     const load = async () => {
+      if (inflight) return;
+      inflight = true;
+      const gen = ++generation;
       try {
         const r = await api<{ report: RemoteReport }>(`/api/remote/threads/${wanted}/report`);
-        if (!cancelled) setReport(r.report);
-      } catch {
-        if (!cancelled) setReport(null);
+        if (!cancelled && gen === generation) {
+          setReport(r.report);
+          setReportError(null);
+        }
+      } catch (err) {
+        if (!cancelled && gen === generation) {
+          setReportError(`Update failed: ${err instanceof Error ? err.message : String(err)}`);
+        }
+      } finally {
+        inflight = false;
       }
     };
     setReport(null);
+    setReportError(null);
     void load();
     const timer = setInterval(() => {
       void load();
@@ -171,28 +192,35 @@ export function RemoteApp() {
     if (!text || sending) return;
     setSending(true);
     setSendError(null);
+    // Move the draft into the optimistic bubble immediately; on failure it
+    // is restored below so nothing the user typed is ever lost.
+    setDraft("");
     try {
       if (!activeId) {
-        if (!projectId || !modelId) return;
-        setPending(text);
+        if (!projectId || !modelId) {
+          setDraft(text);
+          return;
+        }
         const created = await api<{ thread: RemoteThreadSummary }>("/api/remote/threads", {
           method: "POST",
           body: JSON.stringify({ projectId, modelId, prompt: text }),
         });
         setActiveId(created.thread.id);
+        setPending({ text, threadId: created.thread.id, known: 0 });
       } else {
         // Optimistic: show the bubble instantly; poll confirms delivery.
-        setPending(text);
-        setDraft("");
+        const known = (report?.messages ?? []).filter(
+          (m) => m.role === "user" && m.text === text,
+        ).length;
+        setPending({ text, threadId: activeId, known });
         await api(`/api/remote/threads/${activeId}/prompt`, {
           method: "POST",
           body: JSON.stringify({ prompt: text }),
         });
       }
-      // Clear only on success so a failed send keeps the draft for retry.
-      setDraft("");
       void refresh();
     } catch (err) {
+      setDraft(text);
       setPending(null);
       setSendError(`Send failed: ${err instanceof Error ? err.message : String(err)}`);
     } finally {
@@ -207,13 +235,21 @@ export function RemoteApp() {
     setSidebar(false);
   };
 
-  // Drop the optimistic bubble once the server echo arrives.
+  // Drop the optimistic bubble once the server transcript incorporates the
+  // send: a matching user entry beyond the pre-send count proves delivery.
+  // Scoped to the destination thread so switching chats can't confirm it.
   const confirmedTail = report?.messages.at(-1);
+  const pendingConfirmed =
+    pending &&
+    report &&
+    pending.threadId === report.threadId &&
+    report.messages.filter((m) => m.role === "user" && m.text === pending.text).length >
+      pending.known;
   useEffect(() => {
-    if (pending && confirmedTail?.role === "user" && confirmedTail.text === pending) {
-      setPending(null);
-    }
-  }, [pending, confirmedTail]);
+    if (pendingConfirmed) setPending(null);
+  }, [pendingConfirmed]);
+  const pendingVisible =
+    pending && !pendingConfirmed && pending.threadId === activeId ? pending.text : null;
   useEffect(() => {
     // Sticky-bottom: never yank a user who scrolled up to read. Only scroll
     // when the chat actually grew AND the user was already near the bottom
@@ -222,7 +258,7 @@ export function RemoteApp() {
       activeId,
       report?.messages.length ?? 0,
       confirmedTail?.text.length ?? 0,
-      pending ?? "",
+      pendingVisible ?? "",
       report?.running ? "run" : "idle",
     ].join("|");
     if (sig === chatSig.current) return;
@@ -231,10 +267,10 @@ export function RemoteApp() {
     const el = bodyRef.current;
     if (!el) return;
     const nearBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 120;
-    if (nearBottom || wasNewChat || pending) {
+    if (nearBottom || wasNewChat || pendingVisible) {
       bottomRef.current?.scrollIntoView({ behavior: "smooth", block: "end" });
     }
-  }, [confirmedTail, pending, report?.running, report?.messages.length, activeId]);
+  }, [confirmedTail, pendingVisible, report?.running, report?.messages.length, activeId]);
 
   if (!paired) {
     return (
@@ -365,9 +401,12 @@ export function RemoteApp() {
         ) : (
           <div className="chat">
             {!report ? (
-              <p className="report-status">Loading…</p>
+              <p className="report-status">{reportError ?? "Loading…"}</p>
             ) : (
               <>
+                {reportError && (
+                  <p className="notice warn">Couldn't refresh — showing last update.</p>
+                )}
                 <details className="remote-card thread-meta">
                   <summary>
                     {report.running ? "Running on laptop…" : "Done"}
@@ -391,7 +430,7 @@ export function RemoteApp() {
                     </ul>
                   )}
                 </details>
-                {report.messages.length === 0 && !pending && (
+                {report.messages.length === 0 && !pendingVisible && (
                   <p className="remote-hint">Waiting for the first reply…</p>
                 )}
                 {report.messages.map((m, i) => (
@@ -403,9 +442,9 @@ export function RemoteApp() {
                     {m.role === "user" ? <p>{m.text}</p> : <PhoneMarkdown text={m.text} />}
                   </div>
                 ))}
-                {pending && !(confirmedTail?.role === "user" && confirmedTail.text === pending) && (
+                {pendingVisible && (
                   <div className="bubble me pending">
-                    <p>{pending}</p>
+                    <p>{pendingVisible}</p>
                     <span className="bubble-state">
                       {sending ? "Sending…" : "Sent · waiting for laptop…"}
                     </span>

--- a/src/remote/App.tsx
+++ b/src/remote/App.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { AnimatePresence, motion } from "framer-motion";
 import { List, PaperPlaneTilt, Plus, QrCode } from "@phosphor-icons/react";
+import { PhoneMarkdown } from "./markdown.tsx";
 import type {
   RemoteModel,
   RemoteProject,
@@ -43,6 +44,14 @@ export function RemoteApp() {
   const [scanError, setScanError] = useState<string | null>(null);
   const [sendError, setSendError] = useState<string | null>(null);
   const [sending, setSending] = useState(false);
+  // Optimistic follow-up: shown instantly as "Sending…" until the next
+  // report poll confirms it (server messages include it once appended).
+  const [pending, setPending] = useState<string | null>(null);
+  const bottomRef = useRef<HTMLDivElement>(null);
+  const bodyRef = useRef<HTMLDivElement>(null);
+  // Signature of the visible chat: scroll only when this actually changes,
+  // and only when the user is already near the bottom (sticky-bottom).
+  const chatSig = useRef("");
   const refreshInflight = useRef(false);
 
   // Scanned QR opens /remote#token=… — auto-save so scan = paired.
@@ -90,21 +99,28 @@ export function RemoteApp() {
 
   useEffect(() => {
     if (!activeId || !paired) return;
-    // Stale guard: ignore a report that resolves after switching chats.
+    // Poll while open so Running → Done + final text arrives with no stream.
     const wanted = activeId;
     let cancelled = false;
-    setReport(null);
-    api<{ report: RemoteReport }>(`/api/remote/threads/${wanted}/report`)
-      .then((r) => {
+    const load = async () => {
+      try {
+        const r = await api<{ report: RemoteReport }>(`/api/remote/threads/${wanted}/report`);
         if (!cancelled) setReport(r.report);
-      })
-      .catch(() => {
+      } catch {
         if (!cancelled) setReport(null);
-      });
+      }
+    };
+    setReport(null);
+    void load();
+    const timer = setInterval(() => {
+      void load();
+      void refresh();
+    }, 3000);
     return () => {
       cancelled = true;
+      clearInterval(timer);
     };
-  }, [activeId, paired, threads]);
+  }, [activeId, paired, refresh]);
 
   const scanQr = async () => {
     setScanError(null);
@@ -158,12 +174,16 @@ export function RemoteApp() {
     try {
       if (!activeId) {
         if (!projectId || !modelId) return;
+        setPending(text);
         const created = await api<{ thread: RemoteThreadSummary }>("/api/remote/threads", {
           method: "POST",
           body: JSON.stringify({ projectId, modelId, prompt: text }),
         });
         setActiveId(created.thread.id);
       } else {
+        // Optimistic: show the bubble instantly; poll confirms delivery.
+        setPending(text);
+        setDraft("");
         await api(`/api/remote/threads/${activeId}/prompt`, {
           method: "POST",
           body: JSON.stringify({ prompt: text }),
@@ -173,6 +193,7 @@ export function RemoteApp() {
       setDraft("");
       void refresh();
     } catch (err) {
+      setPending(null);
       setSendError(`Send failed: ${err instanceof Error ? err.message : String(err)}`);
     } finally {
       setSending(false);
@@ -182,8 +203,38 @@ export function RemoteApp() {
   const newChat = () => {
     setActiveId(null);
     setReport(null);
+    setPending(null);
     setSidebar(false);
   };
+
+  // Drop the optimistic bubble once the server echo arrives.
+  const confirmedTail = report?.messages.at(-1);
+  useEffect(() => {
+    if (pending && confirmedTail?.role === "user" && confirmedTail.text === pending) {
+      setPending(null);
+    }
+  }, [pending, confirmedTail]);
+  useEffect(() => {
+    // Sticky-bottom: never yank a user who scrolled up to read. Only scroll
+    // when the chat actually grew AND the user was already near the bottom
+    // (or just switched chats / sent a message).
+    const sig = [
+      activeId,
+      report?.messages.length ?? 0,
+      confirmedTail?.text.length ?? 0,
+      pending ?? "",
+      report?.running ? "run" : "idle",
+    ].join("|");
+    if (sig === chatSig.current) return;
+    const wasNewChat = chatSig.current.split("|")[0] !== String(activeId);
+    chatSig.current = sig;
+    const el = bodyRef.current;
+    if (!el) return;
+    const nearBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 120;
+    if (nearBottom || wasNewChat || pending) {
+      bottomRef.current?.scrollIntoView({ behavior: "smooth", block: "end" });
+    }
+  }, [confirmedTail, pending, report?.running, report?.messages.length, activeId]);
 
   if (!paired) {
     return (
@@ -217,11 +268,11 @@ export function RemoteApp() {
   return (
     <div className="remote-shell">
       <header className="remote-header">
-        <button className="icon-btn" aria-label="History" onClick={() => setSidebar(true)}>
+        <button className="header-btn" aria-label="History" onClick={() => setSidebar(true)}>
           <List size={22} />
         </button>
-        <h1>Omni Remote</h1>
-        <button className="icon-btn" aria-label="New chat" onClick={newChat}>
+        <span className="header-spacer" />
+        <button className="header-btn" aria-label="New chat" onClick={newChat}>
           <Plus size={22} />
         </button>
       </header>
@@ -275,7 +326,7 @@ export function RemoteApp() {
         )}
       </AnimatePresence>
 
-      <div className="remote-body">
+      <div className="remote-body" ref={bodyRef}>
         {loadError && <p className="notice bad">{loadError}</p>}
         {!activeId ? (
           <>
@@ -312,27 +363,67 @@ export function RemoteApp() {
             </p>
           </>
         ) : (
-          <div className="remote-card">
+          <div className="chat">
             {!report ? (
               <p className="report-status">Loading…</p>
             ) : (
               <>
-                <p className="report-status">{report.running ? "Running on laptop…" : "Done"}</p>
-                {report.summary && <p className="report-summary">{report.summary}</p>}
-                {!report.isolated && (
-                  <p className="notice warn">
-                    Ran in project root — no isolated workspace.
-                    {report.isolationNote ? ` Reason: ${report.isolationNote}` : ""}
-                  </p>
+                <details className="remote-card thread-meta">
+                  <summary>
+                    {report.running ? "Running on laptop…" : "Done"}
+                    {report.projectName ? ` · ${report.projectName}` : ""}
+                  </summary>
+                  {report.summary && <p className="report-summary">{report.summary}</p>}
+                  {!report.isolated && (
+                    <p className="notice warn">
+                      Ran in project root — no isolated workspace.
+                      {report.isolationNote ? ` Reason: ${report.isolationNote}` : ""}
+                    </p>
+                  )}
+                  {report.worktreePath && (
+                    <p className="ws-path">workspace: {report.worktreePath}</p>
+                  )}
+                  {report.filesTouched.length > 0 && (
+                    <ul className="file-list">
+                      {report.filesTouched.map((f) => (
+                        <li key={f}>{f}</li>
+                      ))}
+                    </ul>
+                  )}
+                </details>
+                {report.messages.length === 0 && !pending && (
+                  <p className="remote-hint">Waiting for the first reply…</p>
                 )}
-                {report.worktreePath && <p className="ws-path">workspace: {report.worktreePath}</p>}
-                {report.filesTouched.length > 0 && (
-                  <ul className="file-list">
-                    {report.filesTouched.map((f) => (
-                      <li key={f}>{f}</li>
-                    ))}
-                  </ul>
+                {report.messages.map((m, i) => (
+                  <div
+                    // eslint-disable-next-line react/no-array-index-key
+                    key={`${i}-${m.role}-${m.text.slice(0, 24)}`}
+                    className={`bubble ${m.role === "user" ? "me" : "agent"}`}
+                  >
+                    {m.role === "user" ? <p>{m.text}</p> : <PhoneMarkdown text={m.text} />}
+                  </div>
+                ))}
+                {pending && !(confirmedTail?.role === "user" && confirmedTail.text === pending) && (
+                  <div className="bubble me pending">
+                    <p>{pending}</p>
+                    <span className="bubble-state">
+                      {sending ? "Sending…" : "Sent · waiting for laptop…"}
+                    </span>
+                  </div>
                 )}
+                {report.running && (
+                  <div className="bubble agent working">
+                    <span className="dots" aria-label="Working">
+                      <i />
+                      <i />
+                      <i />
+                    </span>
+                  </div>
+                )}
+                {!report.running && !report.finalText && report.messages.length > 0 && (
+                  <p className="report-status">Done</p>
+                )}
+                <div ref={bottomRef} />
               </>
             )}
           </div>
@@ -345,25 +436,27 @@ export function RemoteApp() {
       )}
 
       <footer className="remote-composer">
-        <input
-          value={draft}
-          onChange={(e) => setDraft(e.target.value)}
-          placeholder={!activeId ? "Pick project + model first…" : "Follow up…"}
-          disabled={!activeId && (!projectId || !modelId)}
-          onKeyDown={(e) => {
-            if (e.key === "Enter") void send();
-          }}
-        />
-        <motion.button
-          className="send-btn"
-          onClick={() => void send()}
-          aria-label="Send"
-          disabled={!draft.trim()}
-          whileTap={{ scale: 0.9 }}
-          transition={{ duration: 0.08 }}
-        >
-          <PaperPlaneTilt size={22} weight="fill" />
-        </motion.button>
+        <div className="composer-bar">
+          <input
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            placeholder={!activeId ? "Pick project + model first…" : "Follow up…"}
+            disabled={!activeId && (!projectId || !modelId)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") void send();
+            }}
+          />
+          <motion.button
+            className="composer-send"
+            onClick={() => void send()}
+            aria-label="Send"
+            disabled={!draft.trim() || sending}
+            whileTap={{ scale: 0.9 }}
+            transition={{ duration: 0.08 }}
+          >
+            <PaperPlaneTilt size={20} weight="fill" />
+          </motion.button>
+        </div>
       </footer>
     </div>
   );

--- a/src/remote/markdown.tsx
+++ b/src/remote/markdown.tsx
@@ -1,0 +1,44 @@
+import { memo } from "react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import rehypeSanitize from "rehype-sanitize";
+
+/** Lightweight phone markdown: same engine as desktop (GFM + sanitize),
+ *  plain <pre> code blocks (no Shiki — keeps the phone bundle small). */
+
+function Code({ className, children }: { className?: string; children?: React.ReactNode }) {
+  const text = String(children ?? "").replace(/\n$/, "");
+  const isBlock = text.includes("\n") || /language-/.test(className ?? "");
+  if (isBlock) {
+    return (
+      <pre className="md-pre">
+        <code>{text}</code>
+      </pre>
+    );
+  }
+  return <code className="md-code">{children}</code>;
+}
+
+function PhoneMarkdownBase({ text }: { text: string }) {
+  return (
+    <div className="md">
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm]}
+        rehypePlugins={[rehypeSanitize]}
+        components={{
+          code: Code,
+          pre: ({ children }) => <>{children}</>,
+          a: ({ href, children }) => (
+            <a href={href} target="_blank" rel="noreferrer">
+              {children}
+            </a>
+          ),
+        }}
+      >
+        {text}
+      </ReactMarkdown>
+    </div>
+  );
+}
+
+export const PhoneMarkdown = memo(PhoneMarkdownBase);

--- a/src/remote/remote.css
+++ b/src/remote/remote.css
@@ -134,7 +134,6 @@ body {
   font-size: 15px;
   line-height: 1.5;
   white-space: pre-wrap;
-  word-break: break-word;
 }
 
 /* Chat view: user right, agent left, pending + working states. */
@@ -162,7 +161,7 @@ body {
 .bubble p {
   margin: 0;
   white-space: pre-wrap;
-  word-break: break-word;
+  overflow-wrap: anywhere;
 }
 .bubble.me {
   align-self: flex-end;
@@ -307,7 +306,6 @@ body {
 /* Phone markdown: compact, bubble-safe. Code blocks scroll horizontally. */
 .md {
   overflow-wrap: anywhere;
-  word-break: break-word;
 }
 .md > *:first-child {
   margin-top: 0;

--- a/src/remote/remote.css
+++ b/src/remote/remote.css
@@ -46,33 +46,30 @@ body {
 .remote-header {
   display: flex;
   align-items: center;
-  gap: 4px;
   padding: 10px 12px;
-  background: var(--surface-2);
-  border-bottom: 1px solid rgb(255 255 255 / 0.06);
+  /* No bar background: two floating buttons only. */
+  background: transparent;
+  border-bottom: 0;
 }
 
-.remote-header h1 {
+.header-spacer {
   flex: 1;
-  font-size: 17px;
-  font-weight: 650;
-  margin: 0;
-  text-align: center;
-  letter-spacing: -0.01em;
 }
 
-.icon-btn {
+/* Floating header buttons: each owns its background + rounded corners. */
+.header-btn {
   display: grid;
   place-items: center;
   width: 40px;
   height: 40px;
-  border: 0;
-  border-radius: var(--radius-pill);
-  background: transparent;
+  border: 1px solid rgb(255 255 255 / 0.05);
+  border-radius: 14px;
+  background: var(--surface-2);
   color: var(--ink);
+  box-shadow: var(--shadow-4);
   cursor: pointer;
 }
-.icon-btn:active {
+.header-btn:active {
   background: var(--surface-4);
 }
 
@@ -130,7 +127,98 @@ body {
   color: var(--ink-dim);
 }
 .report-summary {
+  margin: 0 0 8px;
+}
+.report-final {
   margin: 0;
+  font-size: 15px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+/* Chat view: user right, agent left, pending + working states. */
+.chat {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.thread-meta {
+  margin-bottom: 4px;
+}
+.thread-meta summary {
+  font-size: 13px;
+  color: var(--ink-dim);
+  cursor: pointer;
+}
+.bubble {
+  max-width: 88%;
+  padding: 10px 14px;
+  border-radius: 18px;
+  font-size: 15px;
+  line-height: 1.5;
+  box-shadow: var(--shadow-4);
+}
+.bubble p {
+  margin: 0;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+.bubble.me {
+  align-self: flex-end;
+  background: var(--ink);
+  color: #171717;
+  border-bottom-right-radius: 6px;
+}
+.bubble.agent {
+  align-self: flex-start;
+  max-width: 100%;
+  padding: 2px 4px;
+  /* No bubble background: plain report text. */
+  background: none;
+  border: 0;
+  box-shadow: none;
+  border-radius: 0;
+}
+.bubble.pending {
+  opacity: 0.75;
+}
+.bubble-state {
+  display: block;
+  margin-top: 4px;
+  font-size: 12px;
+  opacity: 0.65;
+}
+.bubble.working {
+  padding: 14px 16px;
+}
+.dots {
+  display: inline-flex;
+  gap: 5px;
+}
+.dots i {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--ink-dim);
+  animation: dot-pulse 1.2s infinite ease-in-out;
+}
+.dots i:nth-child(2) {
+  animation-delay: 0.15s;
+}
+.dots i:nth-child(3) {
+  animation-delay: 0.3s;
+}
+@keyframes dot-pulse {
+  0%,
+  100% {
+    opacity: 0.3;
+    transform: translateY(0);
+  }
+  50% {
+    opacity: 1;
+    transform: translateY(-3px);
+  }
 }
 
 .file-list {
@@ -173,41 +261,135 @@ body {
 }
 
 .remote-composer {
-  display: flex;
-  gap: 8px;
   padding: 10px 12px calc(10px + env(safe-area-inset-bottom));
   background: var(--surface-2);
   border-top: 1px solid rgb(255 255 255 / 0.06);
 }
-.remote-composer input {
-  flex: 1;
-  padding: 13px 18px;
-  font-size: 16px;
-  color: var(--ink);
+/* Pill composer bar: [+] input [mic/send] — one rounded unit. */
+.composer-bar {
+  display: flex;
+  align-items: center;
+  gap: 4px;
   background: var(--surface-3);
   border: 1px solid rgb(255 255 255 / 0.08);
-  border-radius: var(--radius-pill);
+  border-radius: 28px;
+  padding: 6px 6px 6px 18px;
+}
+.composer-bar input {
+  flex: 1;
+  min-width: 0;
+  border: 0;
   outline: none;
+  background: transparent;
+  color: var(--ink);
+  font-size: 16px;
+  padding: 10px 6px;
 }
-.remote-composer input:focus {
-  border-color: rgb(125 211 252 / 0.5);
+.composer-bar input::placeholder {
+  color: var(--ink-faint);
 }
-.send-btn {
+.composer-send {
   display: grid;
   place-items: center;
-  width: 48px;
-  height: 48px;
+  width: 40px;
+  height: 40px;
+  flex-shrink: 0;
   border: 0;
   border-radius: 50%;
   background: var(--ink);
   color: #171717;
   cursor: pointer;
-  flex-shrink: 0;
 }
-.send-btn:disabled {
-  opacity: 0.3;
+.composer-send:disabled {
+  opacity: 0.4;
 }
 
+/* Phone markdown: compact, bubble-safe. Code blocks scroll horizontally. */
+.md {
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+.md > *:first-child {
+  margin-top: 0;
+}
+.md > *:last-child {
+  margin-bottom: 0;
+}
+.md p {
+  margin: 0 0 8px;
+  line-height: 1.5;
+}
+.md ul,
+.md ol {
+  margin: 0 0 8px;
+  padding-left: 20px;
+}
+.md li {
+  margin: 2px 0;
+}
+.md li > p {
+  margin: 0;
+  display: inline;
+}
+.md blockquote {
+  margin: 0 0 8px;
+  padding-left: 10px;
+  border-left: 3px solid rgb(255 255 255 / 0.2);
+  color: var(--ink-dim);
+}
+.md a {
+  color: var(--accent);
+}
+.md-code {
+  font-family: ui-monospace, monospace;
+  font-size: 13px;
+  background: rgb(0 0 0 / 0.3);
+  border-radius: 6px;
+  padding: 1px 5px;
+}
+.md-pre {
+  margin: 0 0 8px;
+  padding: 10px 12px;
+  background: rgb(0 0 0 / 0.35);
+  border-radius: 12px;
+  overflow-x: auto;
+  font-size: 13px;
+  line-height: 1.45;
+}
+.md-pre code {
+  font-family: ui-monospace, monospace;
+  white-space: pre;
+}
+.md table {
+  display: block;
+  overflow-x: auto;
+  border-collapse: collapse;
+  font-size: 13px;
+  margin: 0 0 8px;
+}
+.md th,
+.md td {
+  border: 1px solid rgb(255 255 255 / 0.12);
+  padding: 6px 8px;
+  text-align: left;
+}
+.md h1,
+.md h2,
+.md h3,
+.md h4 {
+  margin: 10px 0 6px;
+  line-height: 1.3;
+}
+.md h1 {
+  font-size: 18px;
+}
+.md h2 {
+  font-size: 16px;
+}
+.md h3,
+.md h4 {
+  font-size: 15px;
+}
 .remote-sheet-scrim {
   position: fixed;
   inset: 0;


### PR DESCRIPTION
Phone PWA now returns the full final agent reply (no live stream) via getThreadTranscript, renders a chat view with optimistic send states, sticky-bottom scroll, markdown, and a restyled composer/header, creates phone threads in the background without stealing desktop focus, and names phone worktrees phone-xxxxxxxx instead of deriving from prompt text.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned the remote phone experience as a live chat interface.
  * Agent responses now support lightweight Markdown formatting, including links, code blocks, and tables.
  * Added optimistic sending feedback, loading indicators, and automatic updates for active conversations.
  * Added expandable thread details and clearer conversation metadata.
  * Phone-created conversations can now run in the background without interrupting the active workspace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR expands the phone PWA into a polled chat interface with sanitized Markdown, optimistic send states, transcript reporting, randomized phone worktrees, cache controls, and background thread creation that aims not to disturb desktop focus.
- Adds text-only phone transcripts and chat rendering.
- Creates and sends phone threads in the background.
- Restricts cleartext remote binding to loopback and Tailscale addresses.
- Addresses prior optimistic-message, polling-order, and prompt-logging findings.

<h3>Confidence Score: 2/5</h3>

The PR is not yet safe to merge because background follow-ups can leave desktop state on the wrong agent or workspace, and initial prompt failures are falsely presented as accepted sends.

Background restoration reverses only part of `switchThread`'s state changes, and initial thread creation returns before prompt acceptance while suppressing the resulting failure from the client. The previous transcript finding remains partially unresolved: active-turn text is now withheld while streaming, but one logical assistant turn can still be emitted as several phone messages because transcript construction exposes individual `agent_text` entries rather than grouping the assistant run.

**Files Needing Attention:** electron/agent-connection-manager.ts, electron/remote-server.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| electron/agent-connection-manager.ts | Adds transcript extraction and background thread operations, but background restoration omits state changed by `switchThread`; the earlier transcript finding is also only partially addressed because logical replies may still be fragmented. |
| electron/remote-server.ts | Adds safer binding, report caching controls, and background thread startup, but acknowledges initial thread creation before prompt acceptance and hides execution failures from the phone. |
| src/remote/App.tsx | Implements the chat UI, scoped optimistic messages, sticky scrolling, and single-flight polling; the previous pending-message and polling-regression findings are fixed. |
| src/remote/markdown.tsx | Adds sanitized GFM rendering for phone agent messages with lightweight code rendering. |
| contracts/remote.ts | Extends remote reports with transcript messages, final text, and project identity. |
| src/remote/remote.css | Restyles the remote interface for chat bubbles, Markdown, metadata, and the composer. |

<sub>Reviews (2): Last reviewed commit: ["Address review bots: pending states, pol..."](https://github.com/maker-or/omni/commit/524a822254f8bd7dd0beb2e5d60de1aa1f7939ac) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61110829)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->