### PR TITLE
Add per-stage onboarding funnel analytics

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -669,6 +669,10 @@ async function handleAuthCallback(url: string): Promise<void> {
     name: record.name,
     avatarUrl: record.avatar_url,
   });
+  captureAnalytics("onboarding_step", {
+    windowType: "launch",
+    properties: { step: "auth_callback_succeeded", status: "complete", success: true },
+  });
 
   if (launchWindow && !launchWindow.isDestroyed()) {
     launchWindow.webContents.send("launch:authComplete", record);
@@ -739,6 +743,10 @@ async function ensureAuthCallbackServer(): Promise<number> {
         })
         .catch((error) => {
           console.error("[Main] Auth callback handling failed:", error);
+          captureAnalytics("onboarding_step", {
+            windowType: "launch",
+            properties: { step: "auth_callback_failed", status: "failed", success: false },
+          });
           res.writeHead(500, { "Content-Type": "text/plain; charset=utf-8" });
           res.end("Auth callback failed");
         });
@@ -1517,8 +1525,53 @@ function registerIpc(): void {
           ? appendReturnTo(resolveExternalUrl("clerkSignIn"))
           : url;
 
+    const authStep = url === "clerk:sign-up" ? "sign_up_initiated" : "sign_in_initiated";
+    captureAnalytics("onboarding_step", {
+      windowType: "launch",
+      properties: { step: authStep, status: "running", success: true },
+    });
     await shell.openExternal(assertAllowedExternalUrl(resolvedUrl));
   });
+
+  // Allowlist: renderer can only emit these funnel steps. Anything else is
+  // dropped so a compromised/buggy renderer can't explode PostHog cardinality.
+  const ONBOARDING_STEPS = new Set([
+    "sign_in_clicked",
+    "sign_up_clicked",
+    "auth_completed",
+    "stage_agent_viewed",
+    "stage_sleepless_viewed",
+    "stage_shortcuts_viewed",
+    "stage_list_viewed",
+    "stage_add_viewed",
+    "agent_pick_completed",
+    "agent_repick_started",
+    "sleepless_enabled",
+    "sleepless_skipped",
+    "sleepless_completed",
+    "shortcuts_completed",
+    "add_project_started",
+    "add_project_completed",
+    "add_project_abandoned",
+    "project_opened",
+  ]);
+  const ONBOARDING_STATUSES = new Set(["viewed", "running", "complete", "skipped", "failed"]);
+  ipcMain.handle(
+    "analytics:trackOnboarding",
+    (_event, step: string, status: string, success?: boolean) => {
+      const cleanStep = String(step ?? "").slice(0, 80);
+      const cleanStatus = String(status ?? "").slice(0, 24);
+      if (!ONBOARDING_STEPS.has(cleanStep) || !ONBOARDING_STATUSES.has(cleanStatus)) return;
+      captureAnalytics("onboarding_step", {
+        windowType: "launch",
+        properties: {
+          step: cleanStep,
+          status: cleanStatus,
+          success: success ?? (cleanStatus !== "skipped" && cleanStatus !== "failed"),
+        },
+      });
+    },
+  );
 
   ipcMain.handle("launch:complete", async (_event, projectId: string) => {
     requireAuthenticatedUserForLaunch();
@@ -1544,6 +1597,10 @@ function registerIpc(): void {
 
     setActiveProjectId(projectId);
     await markLaunchComplete(projectId);
+    captureAnalytics("onboarding_step", {
+      windowType: "launch",
+      properties: { step: "launch_completed", status: "complete", success: true, project_id: projectId },
+    });
     await requireAgentManager().activateProject(projectId);
 
     if (launchWindow && !launchWindow.isDestroyed()) {

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1526,11 +1526,19 @@ function registerIpc(): void {
           : url;
 
     const authStep = url === "clerk:sign-up" ? "sign_up_initiated" : "sign_in_initiated";
+    try {
+      await shell.openExternal(assertAllowedExternalUrl(resolvedUrl));
+    } catch (error) {
+      captureAnalytics("onboarding_step", {
+        windowType: "launch",
+        properties: { step: authStep, status: "failed", success: false },
+      });
+      throw error;
+    }
     captureAnalytics("onboarding_step", {
       windowType: "launch",
       properties: { step: authStep, status: "running", success: true },
     });
-    await shell.openExternal(assertAllowedExternalUrl(resolvedUrl));
   });
 
   // Allowlist: renderer can only emit these funnel steps. Anything else is
@@ -1554,11 +1562,14 @@ function registerIpc(): void {
     "add_project_completed",
     "add_project_abandoned",
     "project_opened",
+    "project_open_failed",
   ]);
   const ONBOARDING_STATUSES = new Set(["viewed", "running", "complete", "skipped", "failed"]);
   ipcMain.handle(
     "analytics:trackOnboarding",
-    (_event, step: string, status: string, success?: boolean) => {
+    (event, step: string, status: string, success?: boolean) => {
+      // Only the launch window may emit launch-funnel events.
+      if (event.sender !== launchWindow?.webContents) return;
       const cleanStep = String(step ?? "").slice(0, 80);
       const cleanStatus = String(status ?? "").slice(0, 24);
       if (!ONBOARDING_STEPS.has(cleanStep) || !ONBOARDING_STATUSES.has(cleanStatus)) return;
@@ -1592,16 +1603,28 @@ function registerIpc(): void {
       mainWindow.show();
       mainWindow.focus();
       broadcastToWindows("projects:listChanged", project);
+      captureAnalytics("onboarding_step", {
+        windowType: "launch",
+        properties: { step: "launch_completed", status: "complete", success: true, project_id: projectId },
+      });
       return;
     }
 
-    setActiveProjectId(projectId);
-    await markLaunchComplete(projectId);
+    try {
+      setActiveProjectId(projectId);
+      await markLaunchComplete(projectId);
+      await requireAgentManager().activateProject(projectId);
+    } catch (error) {
+      captureAnalytics("onboarding_step", {
+        windowType: "launch",
+        properties: { step: "launch_failed", status: "failed", success: false, project_id: projectId },
+      });
+      throw error;
+    }
     captureAnalytics("onboarding_step", {
       windowType: "launch",
       properties: { step: "launch_completed", status: "complete", success: true, project_id: projectId },
     });
-    await requireAgentManager().activateProject(projectId);
 
     if (launchWindow && !launchWindow.isDestroyed()) {
       launchWindow.close();

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -402,6 +402,8 @@ const api = {
   analytics: {
     captureException: (input: { name: string; message: string; stack?: string }): Promise<void> =>
       ipcRenderer.invoke("analytics:captureException", input),
+    trackOnboarding: (step: string, status: string, success?: boolean): Promise<void> =>
+      ipcRenderer.invoke("analytics:trackOnboarding", step, status, success),
   },
   startup: {
     reportRendererMilestone: (label: string, rendererElapsedMs: number): void =>

--- a/marketing/src/pages/download.astro
+++ b/marketing/src/pages/download.astro
@@ -42,6 +42,11 @@ const windowsLauncherManifestUrl = "/api/launcher/latest-windows.json";
                     Download pipper code
                 </h1>
                 <p
+                    class="download-sub text-[0.9rem] opacity-0 animate-fade-in [animation-delay:100ms]"
+                >
+                    One-time setup before first launch.
+                </p>
+                <p
                     class="text-[0.9rem] text-page-fg opacity-0 animate-fade-in [animation-delay:100ms] flex flex-wrap items-center justify-center gap-3"
                 >
                     <span id="version-label" aria-live="polite"></span>
@@ -65,8 +70,25 @@ const windowsLauncherManifestUrl = "/api/launcher/latest-windows.json";
                 aria-label="Unsigned macOS and Windows launch notes"
             >
                 <div id="mac-launch-note">
-                    <strong class="font-medium">macOS note:</strong> Make sure that you
-                    have mise installed, then run the following command in the terminal:
+                    <p class="download-note-title">macOS setup — complete these steps first</p>
+                    <ol class="download-steps">
+                        <li>
+                            <span class="download-step-num" aria-hidden="true">1</span>
+                            <span><strong>Download</strong> the app below.</span>
+                        </li>
+                        <li>
+                            <span class="download-step-num" aria-hidden="true">2</span>
+                            <span><strong>Move</strong> Pipper Code (Alpha).app to Applications.</span>
+                        </li>
+                        <li>
+                            <span class="download-step-num" aria-hidden="true">3</span>
+                            <span><strong>Open</strong> Terminal.</span>
+                        </li>
+                        <li>
+                            <span class="download-step-num" aria-hidden="true">4</span>
+                            <span><strong>Run this command (before opening the app):</strong></span>
+                        </li>
+                    </ol>
                     <code
                         class="block mt-[0.6rem] p-[0.75rem_0.9rem] border border-[rgba(12,58,143,0.15)] rounded-[0.85rem] bg-[rgba(12,58,143,0.04)] whitespace-pre-wrap [overflow-wrap:anywhere] font-geist text-[0.84rem] break-words"
                         >xattr -cr "/Applications/Pipper Code (Alpha).app"</code
@@ -224,6 +246,44 @@ const windowsLauncherManifestUrl = "/api/launcher/latest-windows.json";
     .download-heading h1::first-line { color: var(--download-blue); }
     .download-heading p { margin: 0; color: var(--download-muted) !important; }
     .download-heading a { color: var(--download-blue) !important; }
+    .download-sub { color: var(--download-muted) !important; }
+
+    .download-note-title {
+        margin: 0 0 0.9rem !important;
+        color: var(--download-blue);
+        font-weight: 500;
+    }
+
+    .download-steps {
+        list-style: none;
+        margin: 0 !important;
+        padding: 0 !important;
+        display: flex;
+        flex-direction: column;
+        gap: 0.65rem;
+    }
+
+    .download-steps li {
+        display: flex;
+        align-items: baseline;
+        gap: 0.7rem;
+    }
+
+    .download-step-num {
+        flex-shrink: 0;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 1.5rem;
+        height: 1.5rem;
+        border: 1.5px solid color-mix(in srgb, var(--download-blue) 55%, transparent);
+        color: var(--download-blue);
+        font-size: 0.8rem;
+        font-weight: 600;
+        align-self: center;
+    }
+
+    .download-steps strong { color: var(--download-blue); }
 
     .download-note {
         position: relative;

--- a/src/components/sleepless-onboarding.tsx
+++ b/src/components/sleepless-onboarding.tsx
@@ -22,7 +22,7 @@ const DEFAULT_PREFERENCES: SleeplessPreferences = {
 };
 
 interface SleeplessOnboardingProps {
-  onComplete: () => void;
+  onComplete: (action?: "enabled" | "skipped" | "continued") => void;
 }
 
 export function SleeplessOnboarding({ onComplete }: SleeplessOnboardingProps) {
@@ -69,7 +69,7 @@ export function SleeplessOnboarding({ onComplete }: SleeplessOnboardingProps) {
   const enable = async () => {
     if (!status || busy) return;
     if (status.preferences.enabled && status.serviceStatus === "enabled") {
-      onComplete();
+      onComplete("continued");
       return;
     }
     setBusy(true);
@@ -86,7 +86,7 @@ export function SleeplessOnboarding({ onComplete }: SleeplessOnboardingProps) {
         setStatus(result);
         setPreferences(result.preferences);
         if (result.serviceStatus === "enabled" && result.preferences.enabled) {
-          onComplete();
+          onComplete("enabled");
           return;
         }
         setError(result.error ?? "The helper could not be installed.");
@@ -98,7 +98,7 @@ export function SleeplessOnboarding({ onComplete }: SleeplessOnboardingProps) {
     }
   };
 
-  const skip = () => onComplete();
+  const skip = () => onComplete("skipped");
   const supported = status?.supported !== false;
   const configured = status?.preferences.enabled && status.serviceStatus === "enabled";
   const displayedError = error ?? status?.error;

--- a/src/electron.d.ts
+++ b/src/electron.d.ts
@@ -266,6 +266,7 @@ declare global {
           message: string;
           stack?: string;
         }) => Promise<void>;
+        trackOnboarding: (step: string, status: string, success?: boolean) => Promise<void>;
       };
       startup: {
         reportRendererMilestone: (label: string, rendererElapsedMs: number) => void;

--- a/src/launch/app.tsx
+++ b/src/launch/app.tsx
@@ -4,6 +4,7 @@ import type { Project } from "../../contracts/projects.ts";
 import { toast } from "@/components/ui/toast";
 import { UnauthenticatedStage } from "./unauthenticated-stage";
 import { AuthenticatedStage } from "./authenticated-stage";
+import { trackOnboarding } from "./onboarding-analytics";
 import { useLauncherUpdateStore } from "@/store/launcher-update-store";
 import { LauncherUpdateDialog, LauncherUpdateNotice } from "@/components/launcher-update";
 
@@ -75,6 +76,7 @@ export function LaunchApp() {
     const cleanupAuth = window.omni.launch.onAuthComplete
       ? window.omni.launch.onAuthComplete((user) => {
           setAuthUser(user);
+          trackOnboarding("auth_completed", "complete", true);
         })
       : () => {};
 
@@ -109,6 +111,7 @@ export function LaunchApp() {
 
   const handleAuthRedirect = useCallback(async (kind: "sign-in" | "sign-up") => {
     if (!window.omni?.shell?.openExternal) return;
+    trackOnboarding(kind === "sign-in" ? "sign_in_clicked" : "sign_up_clicked", "viewed", true);
     setIsLaunchingAuth(true);
     try {
       await window.omni.shell.openExternal(kind === "sign-in" ? "clerk:sign-in" : "clerk:sign-up");

--- a/src/launch/app.tsx
+++ b/src/launch/app.tsx
@@ -91,8 +91,10 @@ export function LaunchApp() {
     setIsOpening(true);
     try {
       await window.omni.launch.complete(projectId);
+      trackOnboarding("project_opened", "complete", true);
     } catch (err) {
       console.error("Failed to complete launch:", err);
+      trackOnboarding("project_open_failed", "failed", false);
       if (err instanceof Error && err.message.includes("Sign in is required")) {
         setAuthUser(null);
       }

--- a/src/launch/authenticated-stage.tsx
+++ b/src/launch/authenticated-stage.tsx
@@ -9,6 +9,7 @@ import { AmbientPixelField } from "@/components/ambient-pixel-field";
 import { AgentSelector } from "@/components/agent-selector";
 import { useAgentRegistryStore } from "@/store/agent-registry-store";
 import { SleeplessOnboarding } from "@/components/sleepless-onboarding";
+import { trackOnboarding } from "./onboarding-analytics";
 
 interface AuthenticatedStageProps {
   authUser: { name: string | null; email: string | null };
@@ -26,6 +27,20 @@ type LaunchStage = "agent" | "sleepless" | "shortcuts" | "list" | "add";
 const AGENT_PICK_STORAGE_KEY = "pipper.launch.agentPicked";
 const SLEEPLESS_ONBOARDING_STORAGE_KEY = "pipper.launch.sleeplessConfigured";
 const SHORTCUTS_ONBOARDING_STORAGE_KEY = "pipper.launch.shortcutsShown";
+
+function isOnboardingFlagSet(key: string): boolean {
+  try {
+    return sessionStorage.getItem(key) === "1";
+  } catch {
+    return true;
+  }
+}
+
+function modifierSymbol(): string {
+  return typeof navigator !== "undefined" && /Mac|iPhone|iPad/i.test(navigator.platform)
+    ? "⌘"
+    : "Ctrl";
+}
 
 export function AuthenticatedStage({
   authUser,
@@ -56,13 +71,16 @@ export function AuthenticatedStage({
       if (stageParam === "shortcuts") {
         return "shortcuts";
       }
-      // First-run / explicit agent re-pick: show registry before projects.
-      try {
-        if (sessionStorage.getItem(AGENT_PICK_STORAGE_KEY) !== "1") {
-          return "agent";
-        }
-      } catch {
+      // First-run funnel: agent → sleepless → shortcuts → list. Returning
+      // users who completed an earlier step resume at the next unfinished one.
+      if (!isOnboardingFlagSet(AGENT_PICK_STORAGE_KEY)) {
         return "agent";
+      }
+      if (!isOnboardingFlagSet(SLEEPLESS_ONBOARDING_STORAGE_KEY)) {
+        return "sleepless";
+      }
+      if (!isOnboardingFlagSet(SHORTCUTS_ONBOARDING_STORAGE_KEY)) {
+        return "shortcuts";
       }
     }
     return "list";
@@ -71,6 +89,10 @@ export function AuthenticatedStage({
   useEffect(() => {
     void loadAgents();
   }, [loadAgents]);
+
+  useEffect(() => {
+    trackOnboarding(`stage_${stage}_viewed`, "viewed", true);
+  }, [stage]);
 
   return (
     <div className="h-screen w-screen relative overflow-hidden bg-[#171717] text-foreground flex items-center justify-center p-6">
@@ -96,6 +118,7 @@ export function AuthenticatedStage({
             <AgentSelector
               showContinue
               onContinue={() => {
+                trackOnboarding("agent_pick_completed", "complete", true);
                 try {
                   sessionStorage.setItem(AGENT_PICK_STORAGE_KEY, "1");
                   if (sessionStorage.getItem(SLEEPLESS_ONBOARDING_STORAGE_KEY) !== "1") {
@@ -115,7 +138,16 @@ export function AuthenticatedStage({
           </>
         ) : stage === "sleepless" ? (
           <SleeplessOnboarding
-            onComplete={() => {
+            onComplete={(action = "continued") => {
+              trackOnboarding(
+                action === "enabled"
+                  ? "sleepless_enabled"
+                  : action === "skipped"
+                    ? "sleepless_skipped"
+                    : "sleepless_completed",
+                action === "skipped" ? "skipped" : "complete",
+                action !== "skipped",
+              );
               try {
                 sessionStorage.setItem(SLEEPLESS_ONBOARDING_STORAGE_KEY, "1");
               } catch {
@@ -128,6 +160,35 @@ export function AuthenticatedStage({
               setStage("list");
             }}
           />
+        ) : stage === "shortcuts" ? (
+          <div className="flex flex-col gap-4">
+            <header className="flex flex-col gap-1">
+              <h1 className="text-xl font-bold tracking-tight">Keyboard shortcuts</h1>
+              <p className="text-xs text-muted-foreground">
+                Press <kbd className="rounded border border-border px-1">{modifierSymbol()}</kbd>+
+                <kbd className="rounded border border-border px-1">T</kbd> for a new thread,{" "}
+                <kbd className="rounded border border-border px-1">{modifierSymbol()}</kbd>+
+                <kbd className="rounded border border-border px-1">W</kbd> to close a tab,{" "}
+                <kbd className="rounded border border-border px-1">{modifierSymbol()}</kbd>+
+                <kbd className="rounded border border-border px-1">1–9</kbd> to switch tabs.
+              </p>
+            </header>
+            <Button
+              type="button"
+              size="md"
+              onClick={() => {
+                trackOnboarding("shortcuts_completed", "complete", true);
+                try {
+                  sessionStorage.setItem(SHORTCUTS_ONBOARDING_STORAGE_KEY, "1");
+                } catch {
+                  // ignore
+                }
+                setStage("list");
+              }}
+            >
+              Continue
+            </Button>
+          </div>
         ) : stage === "list" ? (
           <>
             <header className="flex flex-col gap-1 pb-2 border-b border-border">
@@ -144,7 +205,10 @@ export function AuthenticatedStage({
                   size="sm"
                   className="h-8 shrink-0 text-[11px]"
                   data-pipper-id="change-agent-button"
-                  onClick={() => setStage("agent")}
+                  onClick={() => {
+                    trackOnboarding("agent_repick_started", "viewed", true);
+                    setStage("agent");
+                  }}
                 >
                   {selectedAgentIds.length > 0
                     ? `Change agents (${selectedAgentIds.length})`
@@ -161,7 +225,10 @@ export function AuthenticatedStage({
                 <Button
                   variant="ghost"
                   size="sm"
-                  onClick={() => setStage("add")}
+                  onClick={() => {
+                    trackOnboarding("add_project_started", "viewed", true);
+                    setStage("add");
+                  }}
                   leadingIcon={FolderIcon}
                   className="h-8 text-xs"
                 >
@@ -197,7 +264,10 @@ export function AuthenticatedStage({
                       <button
                         key={project.id}
                         type="button"
-                        onClick={() => handleOpen(project.id)}
+                        onClick={() => {
+                          trackOnboarding("project_opened", "complete", true);
+                          handleOpen(project.id);
+                        }}
                         disabled={isOpening}
                         className={cn(
                           "group flex items-center gap-3 w-full",
@@ -227,7 +297,16 @@ export function AuthenticatedStage({
           </>
         ) : (
           <>
-            <AddProjectForm onBack={() => setStage("list")} onCreated={handleProjectCreated} />
+            <AddProjectForm
+              onBack={() => {
+                trackOnboarding("add_project_abandoned", "skipped", false);
+                setStage("list");
+              }}
+              onCreated={(project) => {
+                trackOnboarding("add_project_completed", "complete", true);
+                handleProjectCreated(project);
+              }}
+            />
           </>
         )}
       </div>

--- a/src/launch/authenticated-stage.tsx
+++ b/src/launch/authenticated-stage.tsx
@@ -264,10 +264,7 @@ export function AuthenticatedStage({
                       <button
                         key={project.id}
                         type="button"
-                        onClick={() => {
-                          trackOnboarding("project_opened", "complete", true);
-                          handleOpen(project.id);
-                        }}
+                        onClick={() => handleOpen(project.id)}
                         disabled={isOpening}
                         className={cn(
                           "group flex items-center gap-3 w-full",

--- a/src/launch/onboarding-analytics.ts
+++ b/src/launch/onboarding-analytics.ts
@@ -1,6 +1,8 @@
 export function trackOnboarding(step: string, status: string, success?: boolean): void {
   try {
-    void window.omni?.analytics?.trackOnboarding?.(step, status, success);
+    void window.omni?.analytics?.trackOnboarding?.(step, status, success)?.catch(() => {
+      // analytics must never break onboarding
+    });
   } catch {
     // analytics must never break onboarding
   }

--- a/src/launch/onboarding-analytics.ts
+++ b/src/launch/onboarding-analytics.ts
@@ -1,0 +1,7 @@
+export function trackOnboarding(step: string, status: string, success?: boolean): void {
+  try {
+    void window.omni?.analytics?.trackOnboarding?.(step, status, success);
+  } catch {
+    // analytics must never break onboarding
+  }
+}


### PR DESCRIPTION
Tracks every onboarding stage (auth, agent pick, sleepless, shortcuts, project list/add, launch) via onboarding_step events with an allowlisted renderer IPC. Fixes returning users skipping the shortcuts step, corrects shortcut copy to real bindings (T/W/1-9) with platform-specific modifier labels, and distinguishes sleepless enable vs skip.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a multi-step onboarding flow covering agent setup, Sleepless, and keyboard shortcuts.
  * Added a dedicated shortcuts onboarding screen with a Continue option.
  * Onboarding actions now reflect whether features were enabled, skipped, or already continued.

* **Improvements**
  * Added tracking for key onboarding milestones, including sign-in, sign-up, authentication, setup completion, project actions, and launch progress.
  * Analytics issues no longer interrupt the onboarding experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->





<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=61941540"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/sphereai/-/pull-requests/maker-or/omni/19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a>Confidence Score: 3/5</h2>

The PR is not yet safe to merge because onboarding completion still does not persist across launch-window sessions and successful project-open analytics can still be lost when that window closes.

<details><summary><h3>Summary</h3></summary>

- Tracks authentication, agent selection, Sleepless, shortcuts, project creation, and launch stages.
- Handles failed launch activation separately and suppresses analytics IPC rejections.
- Updates the download page with a numbered macOS setup sequence.
</details>

<!-- /greptile_comment -->