### PR TITLE
Ship PostHog key in release builds

### DIFF
--- a/.github/workflows/macos-launcher-release.yml
+++ b/.github/workflows/macos-launcher-release.yml
@@ -75,6 +75,10 @@ jobs:
       # This workflow only builds and publishes the macOS DMG.
 
       - name: Build application
+        env:
+          # Baked into the bundle via import.meta.env; without this secret the
+          # shipped app silently captures zero analytics events.
+          VITE_POSTHOG_KEY: ${{ secrets.PIPPER_POSTHOG_KEY }}
         run: bun run build
 
       # Packaging only. `dist` pins `--publish never`, because electron-builder

--- a/.github/workflows/windows-launcher-release.yml
+++ b/.github/workflows/windows-launcher-release.yml
@@ -68,6 +68,9 @@ jobs:
       - name: Build application
         env:
           VITE_PIPPER_LAUNCHER_WINDOWS_UPDATE_MANIFEST_URL: https://github.com/${{ env.PIPPER_RELEASE_REPOSITORY }}/releases/latest/download/latest-windows.json
+          # Baked into the bundle via import.meta.env; without this secret the
+          # shipped app silently captures zero analytics events.
+          VITE_POSTHOG_KEY: ${{ secrets.PIPPER_POSTHOG_KEY }}
         run: bun run build
 
       # Packaging only. `dist:win` pins `--publish never`, because electron-builder

--- a/electron/analytics.ts
+++ b/electron/analytics.ts
@@ -51,10 +51,23 @@ function resolvePostHogHost(): string {
   );
 }
 
+let warnedMissingKey = false;
+
 function getClient(): PostHog | null {
   if (client) return client;
   const apiKey = resolvePostHogKey();
-  if (!apiKey) return null;
+  if (!apiKey) {
+    // Fail loud: a missing key means every capture/identify is a silent no-op.
+    // In release builds this happens when VITE_POSTHOG_KEY wasn't set at build time.
+    if (!warnedMissingKey) {
+      warnedMissingKey = true;
+      console.error(
+        "[Analytics] No PostHog key (PIPPER_POSTHOG_KEY/POSTHOG_KEY/VITE_POSTHOG_KEY). " +
+          "Analytics events will be dropped.",
+      );
+    }
+    return null;
+  }
   client = new PostHog(apiKey, {
     host: resolvePostHogHost(),
     flushAt: 10,


### PR DESCRIPTION
Release DMGs shipped without VITE_POSTHOG_KEY, so the PostHog client never initialized and all production analytics were silently dropped. Both launcher workflows now bake the key from the PIPPER_POSTHOG_KEY secret, and the app logs a one-time error when no key is present instead of failing silently. Requires adding the secret and cutting a fresh release to take effect.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - macOS and Windows launcher builds now support analytics event capture.
- **Bug Fixes**
  - Improved diagnostics when analytics configuration is unavailable by displaying a warning instead of failing silently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62089685"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/sphereai/-/pull-requests/maker-or/omni/20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a>Confidence Score: 4/5</h2>

The PR should not merge until the release workflows fail when the required PostHog key is absent.

<h2>Findings</h2>

1. <img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top">&nbsp;**Missing Secret Still Ships** <a href="https://github.com/maker-or/omni/pull/20#discussion_r3968420817">▶</a>
2. <img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top">&nbsp;**Warning Is Not Durable** <a href="https://github.com/maker-or/omni/pull/20#discussion_r3968420829">▶</a>

<details><summary><h3>Summary</h3></summary>

- Adds `VITE_POSTHOG_KEY` to both launcher build workflows.
- Reports when analytics initialization has no usable key.
- The workflows still need an explicit secret-presence check to prevent publishing another analytics-disabled release.
</details>

<!-- /greptile_comment -->