### PR TITLE
Bake PostHog host into releases, warn on missing key

### DIFF
--- a/.github/workflows/macos-launcher-release.yml
+++ b/.github/workflows/macos-launcher-release.yml
@@ -79,6 +79,9 @@ jobs:
           # Baked into the bundle via import.meta.env; without this secret the
           # shipped app silently captures zero analytics events.
           VITE_POSTHOG_KEY: ${{ secrets.PIPPER_POSTHOG_KEY }}
+          # Optional: set when the PostHog project lives off the default US cloud
+          # (e.g. https://eu.i.posthog.com). Falls back to the US host when unset.
+          VITE_POSTHOG_HOST: ${{ secrets.PIPPER_POSTHOG_HOST }}
         run: bun run build
 
       # Packaging only. `dist` pins `--publish never`, because electron-builder

--- a/.github/workflows/windows-launcher-release.yml
+++ b/.github/workflows/windows-launcher-release.yml
@@ -71,6 +71,9 @@ jobs:
           # Baked into the bundle via import.meta.env; without this secret the
           # shipped app silently captures zero analytics events.
           VITE_POSTHOG_KEY: ${{ secrets.PIPPER_POSTHOG_KEY }}
+          # Optional: set when the PostHog project lives off the default US cloud
+          # (e.g. https://eu.i.posthog.com). Falls back to the US host when unset.
+          VITE_POSTHOG_HOST: ${{ secrets.PIPPER_POSTHOG_HOST }}
         run: bun run build
 
       # Packaging only. `dist:win` pins `--publish never`, because electron-builder

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pipper-code-alpha",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "private": true,
   "type": "module",
   "main": "out/main/index.js",

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -67,4 +67,16 @@ function buildMacSleeplessHelpers() {
 }
 
 buildMacSleeplessHelpers();
+
+// Fail loud: the PostHog key must be present in the build environment
+// (VITE_POSTHOG_KEY secret in CI, .env locally) or the shipped app will
+// silently capture zero analytics events.
+if (!process.env.VITE_POSTHOG_KEY && !process.env.PIPPER_POSTHOG_KEY) {
+  console.warn(
+    "[build] WARNING: no VITE_POSTHOG_KEY/PIPPER_POSTHOG_KEY in the build environment. " +
+      "The packaged app will not report analytics.",
+  );
+} else {
+  console.log("[build] PostHog key present; analytics will be baked in.");
+}
 run(["electron-vite", "build"]);

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -79,4 +79,7 @@ if (!process.env.VITE_POSTHOG_KEY && !process.env.PIPPER_POSTHOG_KEY) {
 } else {
   console.log("[build] PostHog key present; analytics will be baked in.");
 }
+console.log(
+  `[build] PostHog host: ${process.env.VITE_POSTHOG_HOST ?? process.env.PIPPER_POSTHOG_HOST ?? "https://us.i.posthog.com (default)"}`,
+);
 run(["electron-vite", "build"]);


### PR DESCRIPTION
Follows up the PostHog key fix: both launcher workflows now also pass VITE_POSTHOG_HOST (optional, defaults to US cloud), and the build script logs the baked host plus a loud warning when no key is present so deaf releases are caught in CI logs. Includes the 0.0.23 version bump that the v0.0.23 release tag builds from.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Analytics hosting can now be configured for builds targeting non-default PostHog regions.
  * Builds now display the configured analytics host and warn when no analytics key is provided.

* **Chores**
  * Updated the application version to 0.0.23.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62187026"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/sphereai/-/pull-requests/maker-or/omni/21"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a>Confidence Score: 3/5</h2>

The PR is not safe to merge until absent optional host secrets retain the US-cloud default and the build diagnostic reflects the values actually baked by Vite.

<h2>Findings</h2>

1. <img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top">&nbsp;**Unset Host Disables Analytics** <a href="https://github.com/maker-or/omni/pull/21#discussion_r3970789264">▶</a>
2. <img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top">&nbsp;**Diagnostic Misreports Baked Key** <a href="https://github.com/maker-or/omni/pull/21#discussion_r3970789271">▶</a>

<details><summary><h3>Summary</h3></summary>

- Passes the configured PostHog host into both platform builds.
- Logs key presence and the selected host before electron-vite runs.
- Updates package metadata for the v0.0.23 release.
- The optional-host fallback and key diagnostic currently diverge from the application’s actual environment resolution.
</details>

<!-- /greptile_comment -->