### PR TITLE
Link failing onboarding agents to per-agent setup guide

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -614,8 +614,12 @@ function resolveExternalUrl(kind: "clerkSignUp" | "clerkSignIn"): string {
   return kind === "clerkSignUp" ? resolveClerkSignUpUrl() : resolveClerkSignInUrl();
 }
 
+const PIPPER_DOCS_URL_PREFIXES = ["https://www.pipper.dev/docs/", "https://pipper.dev/docs/"];
+
 function isAllowedExternalUrl(inputUrl: string): boolean {
-  return isAllowedClerkAuthUrl(inputUrl);
+  if (isAllowedClerkAuthUrl(inputUrl)) return true;
+  // Onboarding verification cards link failing agents to their setup guide.
+  return PIPPER_DOCS_URL_PREFIXES.some((prefix) => inputUrl.startsWith(prefix));
 }
 
 function assertAllowedExternalUrl(inputUrl: string): string {
@@ -1605,7 +1609,12 @@ function registerIpc(): void {
       broadcastToWindows("projects:listChanged", project);
       captureAnalytics("onboarding_step", {
         windowType: "launch",
-        properties: { step: "launch_completed", status: "complete", success: true, project_id: projectId },
+        properties: {
+          step: "launch_completed",
+          status: "complete",
+          success: true,
+          project_id: projectId,
+        },
       });
       return;
     }
@@ -1617,13 +1626,23 @@ function registerIpc(): void {
     } catch (error) {
       captureAnalytics("onboarding_step", {
         windowType: "launch",
-        properties: { step: "launch_failed", status: "failed", success: false, project_id: projectId },
+        properties: {
+          step: "launch_failed",
+          status: "failed",
+          success: false,
+          project_id: projectId,
+        },
       });
       throw error;
     }
     captureAnalytics("onboarding_step", {
       windowType: "launch",
-      properties: { step: "launch_completed", status: "complete", success: true, project_id: projectId },
+      properties: {
+        step: "launch_completed",
+        status: "complete",
+        success: true,
+        project_id: projectId,
+      },
     });
 
     if (launchWindow && !launchWindow.isDestroyed()) {

--- a/marketing/src/pages/docs/agents.astro
+++ b/marketing/src/pages/docs/agents.astro
@@ -1,0 +1,131 @@
+---
+import Layout from "../../layouts/Layout.astro";
+
+interface AgentDoc {
+  id: string;
+  handle: string;
+  installCmd?: string;
+  signinCmd?: string;
+}
+
+const agents: AgentDoc[] = [
+  { id: "grok", handle: "@grok", installCmd: "npm install -g @xai-official/grok", signinCmd: "grok login" },
+  { id: "claude", handle: "@claude", installCmd: "curl -fsSL https://claude.ai/install.sh | bash", signinCmd: "claude auth login" },
+  { id: "codex", handle: "@codex", installCmd: "curl -fsSL https://chatgpt.com/codex/install.sh | sh", signinCmd: "codex login" },
+  { id: "copilot", handle: "@copilot", installCmd: "npm install -g @github/copilot", signinCmd: "/login" },
+  { id: "cursor", handle: "@cursor", installCmd: "curl https://cursor.com/install -fsS | bash", signinCmd: "agent login" },
+  { id: "opencode", handle: "@opencode", installCmd: "curl -fsSL https://opencode.ai/install | bash", signinCmd: "opencode auth login" },
+  { id: "gemini", handle: "@Gemini", installCmd: "npm install -g @google/gemini-cli", signinCmd: "gemini" },
+  { id: "antigravity", handle: "@antigravity", installCmd: "curl -fsSL https://antigravity.google/cli/install.sh | bash", signinCmd: "agy" },
+];
+---
+
+<Layout
+    title="Connect your assistants — pipper"
+    description="How to set up each AI assistant Pipper works with: Cursor, Codex, Claude, opencode, Grok, Gemini, Copilot, Antigravity."
+    pageClass="docs-page"
+    hideHeader
+    hideFooter
+>
+    <div class="w-full px-3 sm:px-6 py-3 sm:py-5 font-geist" style="background:#f0efed;color:#111;min-height:100svh;">
+        <div class="mx-auto grid lg:grid-cols-[17rem_minmax(0,1fr)]" style="border:1.5px solid #111;min-height:calc(100svh - 1.5rem);max-width:110rem;background:#f0efed;">
+            <aside id="docs-sidebar" class="border-b-[1.5px] lg:border-b-0 lg:border-r-[1.5px] border-[#111] px-6 sm:px-8 py-6 lg:py-8" aria-label="Assistants">
+                <a href="/" class="no-underline text-[1.6rem]" style="color:#111;font-family:'Figtree Variable',sans-serif;font-weight:420;letter-spacing:-0.05em;">Pipper.dev</a>
+                <nav aria-label="Assistants" class="mt-10 lg:mt-14">
+                    <ul class="list-none m-0 p-0 flex lg:flex-col flex-row flex-wrap gap-x-2 gap-y-3">
+                        {agents.map((a, i) => (
+                            <li>
+                                <button type="button" data-agent-tab={a.id} class={`docs-agent-tab ${i === 0 ? "active" : ""}`} style="font-family:'Figtree Variable',sans-serif;font-size:clamp(1.4rem,1.8vw,1.9rem);font-weight:420;letter-spacing:-0.04em;background:none;border:none;cursor:pointer;padding:0.35rem 1.4rem;border-radius:999px;color:#b66509;">
+                                    {a.handle}
+                                </button>
+                            </li>
+                        ))}
+                    </ul>
+                </nav>
+            </aside>
+            <div class="relative px-6 sm:px-12 lg:px-16 py-8 lg:py-12 min-w-0">
+                <a href="/download" class="absolute no-underline text-[1.05rem] px-7 py-2.5" style="top:1.25rem;right:1.25rem;background:#e8d9fa;color:#a54cf1;border:1.5px solid #a54cf1;font-family:'Figtree Variable',sans-serif;">Download</a>
+                {agents.map((a, i) => (
+                    <div data-agent-panel={a.id} class="flex-col gap-7" style={`display:${i === 0 ? "flex" : "none"};`} role="tabpanel" aria-label={a.handle}>
+                        <ol class="list-none m-0 mt-10 p-0 flex flex-col gap-6" style="font-family:'Figtree Variable',sans-serif;">
+                            <li class="flex items-baseline gap-4 text-[clamp(1.3rem,2.2vw,1.8rem)]" style="letter-spacing:-0.02em;">
+                                <svg viewBox="0 0 33 32" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" style="width:1.1em;height:1.1em;flex-shrink:0;align-self:center;overflow:visible;"><g><path d="M9.83385 1.20794L28.9336 13.41C30.7681 14.582 30.5218 17.3345 28.5083 18.1621L6.03476 27.3992C3.49609 28.4426 1.20969 25.4586 2.87767 23.2789L8.9863 15.2959C9.57315 14.529 9.70359 13.5062 9.32802 12.6166L5.90971 4.51905C4.88322 2.08746 7.60963 -0.213023 9.83385 1.20794Z" fill="#FFAA4F"/><path d="M9.83385 1.20794L28.9336 13.41C30.7681 14.582 30.5218 17.3345 28.5083 18.1621L6.03476 27.3992C3.49609 28.4426 1.20969 25.4586 2.87767 23.2789L8.9863 15.2959C9.57315 14.529 9.70359 13.5062 9.32802 12.6166L5.90971 4.51905C4.88322 2.08746 7.60963 -0.213023 9.83385 1.20794Z" stroke="#B1620D" stroke-width="1.53624"/></g></svg>
+                                <span>Open the Terminal</span>
+                            </li>
+                            <li class="flex items-baseline gap-4 text-[clamp(1.3rem,2.2vw,1.8rem)]" style="letter-spacing:-0.02em;">
+                                <svg viewBox="0 0 33 32" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" style="width:1.1em;height:1.1em;flex-shrink:0;align-self:center;overflow:visible;"><g><path d="M9.83385 1.20794L28.9336 13.41C30.7681 14.582 30.5218 17.3345 28.5083 18.1621L6.03476 27.3992C3.49609 28.4426 1.20969 25.4586 2.87767 23.2789L8.9863 15.2959C9.57315 14.529 9.70359 13.5062 9.32802 12.6166L5.90971 4.51905C4.88322 2.08746 7.60963 -0.213023 9.83385 1.20794Z" fill="#FFAA4F"/><path d="M9.83385 1.20794L28.9336 13.41C30.7681 14.582 30.5218 17.3345 28.5083 18.1621L6.03476 27.3992C3.49609 28.4426 1.20969 25.4586 2.87767 23.2789L8.9863 15.2959C9.57315 14.529 9.70359 13.5062 9.32802 12.6166L5.90971 4.51905C4.88322 2.08746 7.60963 -0.213023 9.83385 1.20794Z" stroke="#B1620D" stroke-width="1.53624"/></g></svg>
+                                <span>Paste the command below</span>
+                            </li>
+                            {a.installCmd && (
+                                <li class="sm:pl-10">
+                                    <button type="button" data-copy={a.installCmd} title="Click to copy" class="font-mono cursor-pointer" style="font-size:clamp(0.95rem,1.4vw,1.15rem);background:#ffad4b;color:#7a4a08;border:none;border-radius:999px;padding:0.7rem 1.6rem;max-width:100%;overflow-x:auto;white-space:nowrap;display:inline-block;">{a.installCmd}</button>
+                                </li>
+                            )}
+                            {a.signinCmd && (
+                                <li class="sm:pl-10">
+                                    <button type="button" data-copy={a.signinCmd} title="Click to copy" class="font-mono cursor-pointer" style="font-size:clamp(0.95rem,1.4vw,1.15rem);background:#ffad4b;color:#7a4a08;border:none;border-radius:999px;padding:0.7rem 1.6rem;max-width:100%;overflow-x:auto;white-space:nowrap;display:inline-block;">{a.signinCmd}</button>
+                                </li>
+                            )}
+                            <li class="flex items-baseline gap-4 text-[clamp(1.3rem,2.2vw,1.8rem)]" style="letter-spacing:-0.02em;">
+                                <svg viewBox="0 0 33 32" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" style="width:1.1em;height:1.1em;flex-shrink:0;align-self:center;overflow:visible;"><g><path d="M9.83385 1.20794L28.9336 13.41C30.7681 14.582 30.5218 17.3345 28.5083 18.1621L6.03476 27.3992C3.49609 28.4426 1.20969 25.4586 2.87767 23.2789L8.9863 15.2959C9.57315 14.529 9.70359 13.5062 9.32802 12.6166L5.90971 4.51905C4.88322 2.08746 7.60963 -0.213023 9.83385 1.20794Z" fill="#FFAA4F"/><path d="M9.83385 1.20794L28.9336 13.41C30.7681 14.582 30.5218 17.3345 28.5083 18.1621L6.03476 27.3992C3.49609 28.4426 1.20969 25.4586 2.87767 23.2789L8.9863 15.2959C9.57315 14.529 9.70359 13.5062 9.32802 12.6166L5.90971 4.51905C4.88322 2.08746 7.60963 -0.213023 9.83385 1.20794Z" stroke="#B1620D" stroke-width="1.53624"/></g></svg>
+                                <span>reopen pipper and retry</span>
+                            </li>
+                        </ol>
+                    </div>
+                ))}
+            </div>
+        </div>
+    </div>
+</Layout>
+
+<style is:global>
+    .docs-page { background: #f0efed !important; color: #111111 !important; }
+    .docs-page .main { background: #f0efed; }
+    .docs-page .docs-agent-tab.active { background: #ffad4b !important; color: #7a4a08 !important; }
+    .docs-page .docs-agent-tab:hover { background: rgba(255,173,75,0.3); }
+    .docs-page .docs-agent-tab.active:hover { background: #ffad4b; }
+    .docs-page [data-copy]:hover { filter: brightness(0.96); }
+    .docs-page [data-copy][data-copied="true"] { background: #26B25A !important; color: #24ED75 !important; }
+</style>
+
+<script>
+    const tabs = Array.from(document.querySelectorAll("[data-agent-tab]"));
+    const panels = Array.from(document.querySelectorAll("[data-agent-panel]"));
+    function select(id: string) {
+        tabs.forEach((t) => t.classList.toggle("active", t.getAttribute("data-agent-tab") === id));
+        panels.forEach((p) => {
+            (p as HTMLElement).style.display = p.getAttribute("data-agent-panel") === id ? "flex" : "none";
+        });
+        try {
+            history.replaceState(null, "", `#${id}`);
+        } catch {
+            // ignore
+        }
+    }
+    tabs.forEach((t) => {
+        t.addEventListener("click", () => select(t.getAttribute("data-agent-tab") ?? ""));
+    });
+    const initial = window.location.hash.slice(1);
+    if (initial && document.querySelector(`[data-agent-panel="${initial}"]`)) {
+        select(initial);
+    }
+    document.querySelectorAll("[data-copy]").forEach((btn) => {
+        btn.addEventListener("click", async () => {
+            const el = btn as HTMLElement;
+            const text = btn.getAttribute("data-copy") ?? "";
+            try {
+                await navigator.clipboard.writeText(text);
+            } catch {
+                // clipboard unavailable — still show feedback, user can select manually
+            }
+            if (el.hasAttribute("data-copied")) return;
+            const original = el.textContent;
+            el.setAttribute("data-copied", "true");
+            el.textContent = "Copied ✓";
+            setTimeout(() => {
+                el.removeAttribute("data-copied");
+                el.textContent = original;
+            }, 1500);
+        });
+    });
+</script>

--- a/src/components/agent-selector.tsx
+++ b/src/components/agent-selector.tsx
@@ -286,6 +286,29 @@ function AgentOption({
 }
 
 /**
+ * Registry id → anchor on the marketing setup guide (`/docs/agents`).
+ * Failed verification cards link here so users can install / sign in
+ * without leaving onboarding context.
+ */
+const SETUP_GUIDE_BASE_URL = "https://www.pipper.dev/docs/agents";
+
+const SETUP_GUIDE_DOC_IDS: Record<string, string> = {
+  "cursor-acp": "cursor",
+  "codex-acp": "codex",
+  "claude-agent-acp": "claude",
+  "opencode-acp": "opencode",
+  "grok-acp": "grok",
+  "gemini-acp": "gemini",
+  "copilot-acp": "copilot",
+  "antigravity-acp": "antigravity",
+};
+
+function setupGuideUrl(agentId: string): string | null {
+  const docId = SETUP_GUIDE_DOC_IDS[agentId];
+  return docId ? `${SETUP_GUIDE_BASE_URL}#${docId}` : null;
+}
+
+/**
  * Setup card — stays visible for the whole walkthrough.
  * Inline: logo + name + trailing status (spinner | check | retry).
  */
@@ -314,6 +337,16 @@ function AgentSetupCard({
     result.status === "needs-auth"
       ? `Sign in required for ${descriptor.displayName}. Retry after authenticating`
       : `Retry ${descriptor.displayName}`;
+  const guideUrl = status === "ready" ? null : setupGuideUrl(descriptor.id);
+
+  const openSetupGuide = async () => {
+    if (!guideUrl || !window.omni?.shell?.openExternal) return;
+    try {
+      await window.omni.shell.openExternal(guideUrl);
+    } catch {
+      // Link is a convenience — a blocked popup must never break the walkthrough.
+    }
+  };
 
   return (
     <Card selected={status === "ready"} data-pipper-id={`agent-setup-card-${descriptor.id}`}>
@@ -337,16 +370,30 @@ function AgentSetupCard({
             data-pipper-id={`agent-setup-ready-${descriptor.id}`}
           />
         ) : (
-          <button
-            type="button"
-            onClick={onRetry}
-            title={result.message ?? retryLabel}
-            aria-label={retryLabel}
-            data-pipper-id={`agent-setup-retry-${descriptor.id}`}
-            className="inline-flex size-7 items-center justify-center text-muted-foreground hover:text-foreground outline-none focus-visible:ring-1 focus-visible:ring-ring"
-          >
-            <ArrowsClockwiseIcon size={16} />
-          </button>
+          <span className="inline-flex items-center gap-2">
+            {guideUrl && (
+              <button
+                type="button"
+                onClick={() => void openSetupGuide()}
+                title={`Open setup steps for ${descriptor.displayName}`}
+                aria-label={`Open setup guide for ${descriptor.displayName}`}
+                data-pipper-id={`agent-setup-guide-${descriptor.id}`}
+                className="text-xs text-muted-foreground underline underline-offset-4 hover:text-foreground outline-none focus-visible:ring-1 focus-visible:ring-ring"
+              >
+                Setup guide
+              </button>
+            )}
+            <button
+              type="button"
+              onClick={onRetry}
+              title={result.message ?? retryLabel}
+              aria-label={retryLabel}
+              data-pipper-id={`agent-setup-retry-${descriptor.id}`}
+              className="inline-flex size-7 items-center justify-center text-muted-foreground hover:text-foreground outline-none focus-visible:ring-1 focus-visible:ring-ring"
+            >
+              <ArrowsClockwiseIcon size={16} />
+            </button>
+          </span>
         )}
       </CardFooter>
     </Card>


### PR DESCRIPTION
Adds a Setup guide link to failed agent verification cards, deep-linking each agent to its tab on the new /docs/agents page. Widens the external-URL allowlist to pipper.dev/docs so the link can open. The new docs page gives copy-paste install and login commands for all eight supported agents.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added setup guides for configuring Pipper with Grok, Claude, Codex, Copilot, Cursor, opencode, Gemini, and Antigravity.
  - Added agent-specific links from failed verification cards to the relevant setup guide.
  - Added tab navigation, URL-based guide selection, and one-click copying for installation and sign-in commands.

- **Bug Fixes**
  - Setup guide links now open safely from onboarding verification cards while preserving the existing retry option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62618900"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 4/5</h2>

The PR should not merge until the setup commands are aligned with the agent registry, because the new recovery path can leave several failing agents undetectable or unauthenticated.

<h2>Findings</h2>

1. <img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top">&nbsp;**Setup commands install wrong agents** <a href="https://github.com/maker-or/omni/pull/22#discussion_r3980115051">▶</a>
2. <img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top">&nbsp;**Malformed fragments break copy buttons** <a href="https://github.com/maker-or/omni/pull/22#discussion_r3980115060">▶</a>

<h3>Summary</h3>

- The renderer maps each supported registry ID to its documentation tab.
- Electron permits HTTPS links under the `pipper.dev/docs/` paths.
- The new documentation page provides copyable install and authentication commands, although several conflict with the application’s authoritative agent registry.

<sub>Reviews (1) · Last reviewed commit: ["Link failing onboarding agents to per-ag..."](https://github.com/maker-or/omni/commit/d9b5709599eb8369507cabaea571392eabf7bfb2)</sub>

<!-- /greptile_comment -->